### PR TITLE
Reworked API to properly support symbols lookup for WPP decoding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+          lfs: true
 
       - name: Setup .Net SDK
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,15 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           submodules: true
           lfs: true
+          persist-credentials: false
 
       - name: Setup .Net SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: 9.x
 
@@ -25,10 +26,12 @@ jobs:
         run: dotnet build -c Release
 
       - name: Test
+        env:
+          RUN_INTEGRATION_TESTS: "true"
         run: dotnet test -c Release --no-build --logger "trx;LogFileName=test-results.trx"
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: test-results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -22,3 +22,13 @@ jobs:
 
       - name: Build
         run: dotnet build -c Release
+
+      - name: Test
+        run: dotnet test -c Release --no-build --logger "trx;LogFileName=test-results.trx"
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: "**/*.trx"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ contributors.*
 - Currently relies on **Windows-only** APIs so no support for other platforms
 - Not all WPP extended format specification strings are implemented
 - User prefixes are currently not implemented
+- `TmfFileDecodingContextType` (single `.tmf` file path mode / `TDH_CONTEXT_WPP_TMFFILE`) is not yet implemented; use `TmfFilesDirectoryDecodingContextType` instead
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ contributors.*
 - Added support for [WPP Software Tracing](https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/wpp-software-tracing) decoding
   - Supports `.PDB` files as a decoding source
   - Supports `.TMF` files as a decoding source
+- Added `EtwUtil.EnumeratePdbReferences` for lightweight pre-scanning of ETL files to collect all PDB metadata
+  (symbol GUIDs, ages and file names) referenced in the trace before performing a full decode — enabling
+  proper multi-PDB symbol resolution via symbol servers or local paths
 
 ## Known limitations
 

--- a/docs/nefarius.utilities.etw.etwjsonconverteroptions.md
+++ b/docs/nefarius.utilities.etw.etwjsonconverteroptions.md
@@ -12,18 +12,6 @@ Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) 
 
 ## Properties
 
-### <a id="properties-contextproviderlookup"/>**ContextProviderLookup**
-
-Custom [DecodingContext](./nefarius.utilities.etw.deserializer.wpp.decodingcontext.md) provider lookup.
-
-```csharp
-public Func<PdbMetaData, DecodingContextType> ContextProviderLookup { get; set; }
-```
-
-#### Property Value
-
-[Func&lt;PdbMetaData, DecodingContextType&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.func-2)<br>
-
 ### <a id="properties-customprovidermanifest"/>**CustomProviderManifest**
 
 Custom manifest provider lookup.
@@ -76,3 +64,10 @@ public DecodingContext WppDecodingContext { get; set; }
 #### Property Value
 
 [DecodingContext](./nefarius.utilities.etw.deserializer.wpp.decodingcontext.md)<br>
+
+**Remarks:**
+
+Build this context by calling [EtwUtil.EnumeratePdbReferences](./nefarius.utilities.etw.etwutil.md) first to discover all PDB
+references in the trace, resolve each `PdbMetaData` to its actual `.pdb` file, then
+construct a `DecodingContext` from the resulting `PdbFileDecodingContextType` instances
+before calling [EtwUtil.ConvertToJson](./nefarius.utilities.etw.etwutil.md).

--- a/docs/nefarius.utilities.etw.etwjsonconverteroptions.md
+++ b/docs/nefarius.utilities.etw.etwjsonconverteroptions.md
@@ -68,6 +68,13 @@ public DecodingContext WppDecodingContext { get; set; }
 **Remarks:**
 
 Build this context by calling [EtwUtil.EnumeratePdbReferences](./nefarius.utilities.etw.etwutil.md) first to discover all PDB
-references in the trace, resolve each `PdbMetaData` to its actual `.pdb` file, then
-construct a `DecodingContext` from the resulting `PdbFileDecodingContextType` instances
-before calling [EtwUtil.ConvertToJson](./nefarius.utilities.etw.etwutil.md).
+references in the trace, then choose one of two decoding sources for each `PdbMetaData`:
+
+- **`PdbFileDecodingContextType`** — parse the matching `.pdb` file directly (e.g. downloaded from a symbol
+  server using `PdbMetaData.DownloadPath`). Preferred when the PDB is available and accurate decoding is required.
+- **`TmfFilesDirectoryDecodingContextType`** — point at a directory containing pre-extracted `.tmf` files. Use
+  this when PDB files are unavailable but `.tmf` files have already been generated (e.g. with `tracepdb.exe` or
+  WDK tools).
+
+Combine one or more of these into a single `DecodingContext` and pass it here before calling
+[EtwUtil.ConvertToJson](./nefarius.utilities.etw.etwutil.md).

--- a/docs/nefarius.utilities.etw.etwutil.md
+++ b/docs/nefarius.utilities.etw.etwutil.md
@@ -12,6 +12,33 @@ Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) 
 
 ## Methods
 
+### <a id="methods-enumeratepdbReferences"/>**EnumeratePdbReferences(IEnumerable&lt;String&gt;, Action&lt;EtwMetadataScanOptions&gt;)**
+
+Performs a lightweight pre-scan of one or more `.ETL` files and returns the deduplicated set of `PdbMetaData` entries
+discovered in the trace's image-ID events.
+
+```csharp
+public static IReadOnlyCollection<PdbMetaData> EnumeratePdbReferences(IEnumerable<String> inputFiles, Action<EtwMetadataScanOptions> options)
+```
+
+#### Parameters
+
+`inputFiles` [IEnumerable&lt;String&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1)<br>
+One or more input `.etl` files to scan.
+
+`options` [Action&lt;EtwMetadataScanOptions&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.action-1)<br>
+Optional callback to configure scan behaviour and subscribe to image-ID event notifications.
+
+#### Returns
+
+A deduplicated, read-only collection of every `PdbMetaData` referenced by the trace. Use these entries to locate or
+download the corresponding `.pdb` files, then pass the resulting
+[DecodingContext](./nefarius.utilities.etw.deserializer.wpp.decodingcontext.md) to
+[ConvertToJson](#methods-converttojson) via
+[EtwJsonConverterOptions.WppDecodingContext](./nefarius.utilities.etw.etwjsonconverteroptions.md).
+
+---
+
 ### <a id="methods-converttojson"/>**ConvertToJson(Utf8JsonWriter, IEnumerable&lt;String&gt;, Action&lt;EtwJsonConverterOptions&gt;)**
 
 Converts one or more .ETL files to a JSON object.

--- a/docs/nefarius.utilities.etw.etwutil.md
+++ b/docs/nefarius.utilities.etw.etwutil.md
@@ -15,24 +15,25 @@ Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) 
 ### <a id="methods-enumeratepdbReferences"/>**EnumeratePdbReferences(IEnumerable&lt;String&gt;, Action&lt;EtwMetadataScanOptions&gt;)**
 
 Performs a lightweight pre-scan of one or more `.ETL` files and returns the deduplicated set of `PdbMetaData` entries
-discovered in the trace's image-ID events.
+discovered in the trace's image-ID, RSDS, kernel, and file-version events.
 
 ```csharp
-public static IReadOnlyCollection<PdbMetaData> EnumeratePdbReferences(IEnumerable<String> inputFiles, Action<EtwMetadataScanOptions> options)
+public static IReadOnlyCollection<PdbMetaData> EnumeratePdbReferences(IEnumerable<String> inputFiles, Action<EtwMetadataScanOptions>? options = null)
 ```
 
 #### Parameters
 
 `inputFiles` [IEnumerable&lt;String&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1)<br>
-One or more input `.etl` files to scan.
+One or more input `.etl` files to scan. Must not be `null` and must not contain any `null` or whitespace-only entries.
 
 `options` [Action&lt;EtwMetadataScanOptions&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.action-1)<br>
-Optional callback to configure scan behaviour and subscribe to image-ID event notifications.
+Optional (default `null`) callback to configure scan behaviour and subscribe to image-ID (`OnImageId`),
+RSDS (`OnDbgIdRsds`), kernel RSDS (`OnKernelDbgIdRsds`), and file-version (`OnImageIdFileVersion`) event notifications.
 
 #### Returns
 
 A deduplicated, read-only collection of every `PdbMetaData` referenced by the trace. Use these entries to locate or
-download the corresponding `.pdb` files, then pass the resulting
+download the corresponding `.pdb` files (or find matching `.tmf` files), then pass the resulting
 [DecodingContext](./nefarius.utilities.etw.deserializer.wpp.decodingcontext.md) to
 [ConvertToJson](#methods-converttojson) via
 [EtwJsonConverterOptions.WppDecodingContext](./nefarius.utilities.etw.etwjsonconverteroptions.md).

--- a/src/Deserializer/Deserializer.cs
+++ b/src/Deserializer/Deserializer.cs
@@ -41,7 +41,7 @@ internal sealed partial class Deserializer<T>
 
     private readonly Dictionary<Guid, EventSourceManifest> _eventSourceManifestCache = new();
 
-    private EventMetadata[]? _eventMetadataTable;
+    private EventMetadata[] _eventMetadataTable = Array.Empty<EventMetadata>();
 
     private readonly WppTraceEventParser? _wppTraceEventParser;
 

--- a/src/Deserializer/Deserializer.cs
+++ b/src/Deserializer/Deserializer.cs
@@ -41,8 +41,6 @@ internal sealed partial class Deserializer<T>
 
     private readonly Dictionary<Guid, EventSourceManifest> _eventSourceManifestCache = new();
 
-    private readonly Func<PdbMetaData, DecodingContextType?>? _pdbContextProviderLookup;
-
     private EventMetadata[]? _eventMetadataTable;
 
     private readonly WppTraceEventParser? _wppTraceEventParser;
@@ -55,11 +53,9 @@ internal sealed partial class Deserializer<T>
     }
 
     public Deserializer(T writer, Func<Guid, Stream?>? customProviderManifest,
-        DecodingContext? decodingContext = null,
-        Func<PdbMetaData, DecodingContextType?>? pdbContextProviderLookup = null) : this(writer)
+        DecodingContext? decodingContext = null) : this(writer)
     {
         _customProviderManifest = customProviderManifest;
-        _pdbContextProviderLookup = pdbContextProviderLookup;
 
         if (decodingContext is not null)
         {
@@ -321,33 +317,8 @@ internal sealed partial class Deserializer<T>
             return;
         }
 
-#if FIXME
-        // lets the caller react to finding the relevant .PDB(s) before WPP events get parsed, if any
-        if (operand.Metadata.Name.Equals("MSNT_SystemTrace/EventTrace/DbgIdRSDS",
-                StringComparison.InvariantCultureIgnoreCase))
-        {
-            Guid pdbGuid = eventRecordReader.ReadGuid();
-            uint pdbAge = eventRecordReader.ReadUInt32();
-            string pdbName = eventRecordReader.ReadAnsiString();
-
-            // reset or parser will read out of bounds
-            eventRecordReader.Reset();
-
-            PdbMetaData meta = new() { Guid = pdbGuid, Age = (int)pdbAge, PdbName = pdbName };
-
-            DecodingContextType? dct = _pdbContextProviderLookup?.Invoke(meta);
-
-            if (dct is not null)
-            {
-                _wppTraceEventParser = _wppTraceEventParser is null
-                    ? new WppTraceEventParser(new DecodingContext(dct))
-                    : new WppTraceEventParser(_wppTraceEventParser.DecodingContext.ExtendWith(dct));
-            }
-        }
-#endif
-
         _eventMetadataTableList.Add(operand.Metadata);
-        _eventMetadataTable = _eventMetadataTableList.ToArray(); // TODO: Need to improve this
+        _eventMetadataTable = _eventMetadataTableList.ToArray();
 
         ParameterExpression eventRecordReaderParam = Expression.Parameter(ReaderType);
         ParameterExpression eventWriterParam = Expression.Parameter(WriterType);

--- a/src/Deserializer/MetadataScanner.cs
+++ b/src/Deserializer/MetadataScanner.cs
@@ -21,7 +21,7 @@ internal sealed class MetadataScanner
 
     private readonly EtwMetadataScanOptions _options;
 
-    internal MetadataScanner(EtwMetadataScanOptions options)
+    internal unsafe MetadataScanner(EtwMetadataScanOptions options)
     {
         _options = options;
         _callback = Callback;

--- a/src/Deserializer/MetadataScanner.cs
+++ b/src/Deserializer/MetadataScanner.cs
@@ -1,0 +1,256 @@
+using System.Runtime.InteropServices;
+
+using Windows.Win32.Foundation;
+
+using Nefarius.Utilities.ETW.Deserializer.CustomParsers;
+using Nefarius.Utilities.ETW.Deserializer.WPP;
+using Nefarius.Utilities.ETW.Events;
+
+namespace Nefarius.Utilities.ETW.Deserializer;
+
+/// <summary>
+///     Lightweight single-pass scanner that collects PDB metadata and image-ID family events from one or more ETL files
+///     without invoking the full <see cref="Deserializer{T}" /> machinery (no TDH, no expression-tree compilation).
+/// </summary>
+internal sealed class MetadataScanner
+{
+    // Stored as a field so the GC never collects the delegate while ProcessTrace is running.
+    private readonly PEVENT_RECORD_CALLBACK _callback;
+
+    private readonly HashSet<PdbMetaData> _discovered = new();
+
+    private readonly EtwMetadataScanOptions _options;
+
+    internal MetadataScanner(EtwMetadataScanOptions options)
+    {
+        _options = options;
+        _callback = Callback;
+    }
+
+    internal IReadOnlyCollection<PdbMetaData> Scan(List<string> inputFiles)
+    {
+        int count = inputFiles.Count;
+        EVENT_TRACE_LOGFILEW[] fileSessions = new EVENT_TRACE_LOGFILEW[count];
+        ulong[] handles = new ulong[count];
+
+        for (int i = 0; i < count; ++i)
+        {
+            unsafe
+            {
+                fileSessions[i] = new EVENT_TRACE_LOGFILEW
+                {
+                    LogFileName = inputFiles[i],
+                    EventRecordCallback = _callback,
+                    LogFileMode = PInvoke.PROCESS_TRACE_MODE_EVENT_RECORD
+                };
+
+                handles[i] = Etw.OpenTrace(ref fileSessions[i]);
+            }
+        }
+
+        for (int i = 0; i < handles.Length; ++i)
+        {
+            unchecked
+            {
+                if (handles[i] != (ulong)~0)
+                {
+                    continue;
+                }
+
+                switch ((WIN32_ERROR)Marshal.GetLastWin32Error())
+                {
+                    case WIN32_ERROR.ERROR_INVALID_PARAMETER:
+                        _options.ReportError?.Invoke("ERROR: For file: " + inputFiles[i] +
+                                                     " Windows returned 0x57 -- The Logfile parameter is NULL.");
+                        break;
+                    case WIN32_ERROR.ERROR_BAD_PATHNAME:
+                        _options.ReportError?.Invoke("ERROR: For file: " + inputFiles[i] +
+                                                     " Windows returned 0xA1 -- The specified path is invalid.");
+                        break;
+                    case WIN32_ERROR.ERROR_ACCESS_DENIED:
+                        _options.ReportError?.Invoke("ERROR: For file: " + inputFiles[i] +
+                                                     " Windows returned 0x5 -- Access is denied.");
+                        break;
+                    default:
+                        _options.ReportError?.Invoke("ERROR: For file: " + inputFiles[i] +
+                                                     " Windows returned an unknown error.");
+                        break;
+                }
+
+                // Close any handles opened before this failure then bail out.
+                for (int j = 0; j < i; j++)
+                {
+                    Etw.CloseTrace(handles[j]);
+                }
+
+                return _discovered;
+            }
+        }
+
+        Etw.ProcessTrace(handles, (uint)handles.Length, IntPtr.Zero, IntPtr.Zero);
+
+        // Keep fileSessions alive until after ProcessTrace returns so the GC does not collect
+        // the embedded delegate or log-file name strings while the callback can still fire.
+        GC.KeepAlive(fileSessions);
+
+        for (int i = 0; i < count; ++i)
+        {
+            Etw.CloseTrace(handles[i]);
+        }
+
+        return _discovered;
+    }
+
+    private unsafe void Callback(EVENT_RECORD* eventRecord)
+    {
+        Guid providerId = eventRecord->EventHeader.ProviderId;
+        byte opcode = eventRecord->EventHeader.EventDescriptor.Opcode;
+
+        // EventRecordReader uses UserContext as the base pointer for length calculations.
+        eventRecord->UserContext = eventRecord->UserData;
+        EventRecordReader reader = new(eventRecord);
+
+        try
+        {
+            if (providerId == CustomParserGuids.KernelTraceControlImageIdGuid)
+            {
+                switch (opcode)
+                {
+                    case 0:
+                        HandleImageId(reader, eventRecord);
+                        break;
+                    case 36:
+                        HandleDbgIdRsds(reader, eventRecord);
+                        break;
+                    case 64:
+                        HandleImageIdFileVersion(reader, eventRecord);
+                        break;
+                }
+            }
+            else if (providerId == PInvoke.EventTraceGuid && opcode == 36)
+            {
+                HandleKernelDbgIdRsds(reader, eventRecord);
+            }
+        }
+        catch
+        {
+            // Swallow: a malformed or unexpected event payload must not crash the scan.
+        }
+    }
+
+    private unsafe void HandleDbgIdRsds(EventRecordReader reader, EVENT_RECORD* eventRecord)
+    {
+        ulong imageBase = reader.ReadUInt64();
+        uint processId = reader.ReadUInt32();
+        Guid guidSig = reader.ReadGuid();
+        uint age = reader.ReadUInt32();
+        string pdbFileName = reader.ReadAnsiString();
+
+        DbgIdRsdsEventInfo info = new()
+        {
+            Timestamp = eventRecord->EventHeader.TimeStamp,
+            ProcessId = eventRecord->EventHeader.ProcessId,
+            ThreadId = eventRecord->EventHeader.ThreadId,
+            ImageBase = imageBase,
+            GuidSig = guidSig,
+            Age = age,
+            PdbFileName = pdbFileName
+        };
+
+        _options.OnDbgIdRsds?.Invoke(info);
+
+        if (!string.IsNullOrEmpty(pdbFileName))
+        {
+            _discovered.Add(info.ToPdbMetaData());
+        }
+    }
+
+    private unsafe void HandleImageId(EventRecordReader reader, EVENT_RECORD* eventRecord)
+    {
+        if (_options.OnImageId is null)
+        {
+            return;
+        }
+
+        ulong imageBase = reader.ReadPointer();
+        uint imageSize = reader.ReadUInt32();
+        reader.ReadPointer(); // skip extra pointer present in the layout
+        uint timeDateStamp = reader.ReadUInt32();
+        string originalFileName = reader.ReadUnicodeString();
+
+        _options.OnImageId.Invoke(new ImageIdEventInfo
+        {
+            Timestamp = eventRecord->EventHeader.TimeStamp,
+            ProcessId = eventRecord->EventHeader.ProcessId,
+            ThreadId = eventRecord->EventHeader.ThreadId,
+            ImageBase = imageBase,
+            ImageSize = imageSize,
+            TimeDateStamp = timeDateStamp,
+            OriginalFileName = originalFileName
+        });
+    }
+
+    private unsafe void HandleImageIdFileVersion(EventRecordReader reader, EVENT_RECORD* eventRecord)
+    {
+        if (_options.OnImageIdFileVersion is null)
+        {
+            return;
+        }
+
+        uint imageSize = reader.ReadUInt32();
+        uint timeDateStamp = reader.ReadUInt32();
+        string origFileName = reader.ReadUnicodeString();
+        string fileDescription = reader.ReadUnicodeString();
+        string fileVersion = reader.ReadUnicodeString();
+        string binFileVersion = reader.ReadUnicodeString();
+        string verLanguage = reader.ReadUnicodeString();
+        string productName = reader.ReadUnicodeString();
+        string companyName = reader.ReadUnicodeString();
+        string productVersion = reader.ReadUnicodeString();
+        string fileId = reader.ReadUnicodeString();
+        string programId = reader.ReadUnicodeString();
+
+        _options.OnImageIdFileVersion.Invoke(new ImageIdFileVersionEventInfo
+        {
+            Timestamp = eventRecord->EventHeader.TimeStamp,
+            ProcessId = eventRecord->EventHeader.ProcessId,
+            ThreadId = eventRecord->EventHeader.ThreadId,
+            ImageSize = imageSize,
+            TimeDateStamp = timeDateStamp,
+            OrigFileName = origFileName,
+            FileDescription = fileDescription,
+            FileVersion = fileVersion,
+            BinFileVersion = binFileVersion,
+            VerLanguage = verLanguage,
+            ProductName = productName,
+            CompanyName = companyName,
+            ProductVersion = productVersion,
+            FileId = fileId,
+            ProgramId = programId
+        });
+    }
+
+    private unsafe void HandleKernelDbgIdRsds(EventRecordReader reader, EVENT_RECORD* eventRecord)
+    {
+        Guid pdbGuid = reader.ReadGuid();
+        uint age = reader.ReadUInt32();
+        string pdbName = reader.ReadAnsiString();
+
+        KernelDbgIdRsdsEventInfo info = new()
+        {
+            Timestamp = eventRecord->EventHeader.TimeStamp,
+            ProcessId = eventRecord->EventHeader.ProcessId,
+            ThreadId = eventRecord->EventHeader.ThreadId,
+            Guid = pdbGuid,
+            Age = age,
+            PdbName = pdbName
+        };
+
+        _options.OnKernelDbgIdRsds?.Invoke(info);
+
+        if (!string.IsNullOrEmpty(pdbName))
+        {
+            _discovered.Add(info.ToPdbMetaData());
+        }
+    }
+}

--- a/src/Deserializer/MetadataScanner.cs
+++ b/src/Deserializer/MetadataScanner.cs
@@ -32,6 +32,7 @@ internal sealed class MetadataScanner
         int count = inputFiles.Count;
         EVENT_TRACE_LOGFILEW[] fileSessions = new EVENT_TRACE_LOGFILEW[count];
         ulong[] handles = new ulong[count];
+        WIN32_ERROR[] openErrors = new WIN32_ERROR[count];
 
         for (int i = 0; i < count; ++i)
         {
@@ -45,6 +46,8 @@ internal sealed class MetadataScanner
                 };
 
                 handles[i] = Etw.OpenTrace(ref fileSessions[i]);
+                // Capture per-file immediately; subsequent OpenTrace calls would overwrite GetLastWin32Error.
+                openErrors[i] = (WIN32_ERROR)Marshal.GetLastWin32Error();
             }
         }
 
@@ -57,7 +60,7 @@ internal sealed class MetadataScanner
                     continue;
                 }
 
-                WIN32_ERROR lastError = (WIN32_ERROR)Marshal.GetLastWin32Error();
+                WIN32_ERROR lastError = openErrors[i];
                 switch (lastError)
                 {
                     case WIN32_ERROR.ERROR_INVALID_PARAMETER:

--- a/src/Deserializer/MetadataScanner.cs
+++ b/src/Deserializer/MetadataScanner.cs
@@ -57,7 +57,8 @@ internal sealed class MetadataScanner
                     continue;
                 }
 
-                switch ((WIN32_ERROR)Marshal.GetLastWin32Error())
+                WIN32_ERROR lastError = (WIN32_ERROR)Marshal.GetLastWin32Error();
+                switch (lastError)
                 {
                     case WIN32_ERROR.ERROR_INVALID_PARAMETER:
                         _options.ReportError?.Invoke("ERROR: For file: " + inputFiles[i] +
@@ -73,7 +74,7 @@ internal sealed class MetadataScanner
                         break;
                     default:
                         _options.ReportError?.Invoke("ERROR: For file: " + inputFiles[i] +
-                                                     " Windows returned an unknown error.");
+                                                     $" Windows returned an unknown error: 0x{(uint)lastError:X8} ({lastError}).");
                         break;
                 }
 

--- a/src/Deserializer/MetadataScanner.cs
+++ b/src/Deserializer/MetadataScanner.cs
@@ -6,6 +6,8 @@ using Nefarius.Utilities.ETW.Deserializer.CustomParsers;
 using Nefarius.Utilities.ETW.Deserializer.WPP;
 using Nefarius.Utilities.ETW.Events;
 
+// ReSharper disable InconsistentNaming
+
 namespace Nefarius.Utilities.ETW.Deserializer;
 
 /// <summary>
@@ -131,14 +133,57 @@ internal sealed class MetadataScanner
                         break;
                 }
             }
-            else if (providerId == PInvoke.EventTraceGuid && opcode == 36)
+            else if (providerId == PInvoke.EventTraceGuid)
             {
-                HandleKernelDbgIdRsds(reader, eventRecord);
+                // The MSNT_SystemTrace/EventTrace/DbgIdRSDS event has no stable numeric opcode that
+                // works across OS versions.  Replicate the original #if FIXME approach: ask TDH for
+                // the opcode name and match on "DbgIdRSDS" (case-insensitive), exactly as the
+                // original Deserializer.SlowLookup code did via operand.Metadata.Name.
+                TryHandleMsntDbgIdRsdsViaTdh(reader, eventRecord);
             }
         }
         catch
         {
             // Swallow: a malformed or unexpected event payload must not crash the scan.
+        }
+    }
+
+    /// <summary>
+    ///     Calls TDH to resolve the opcode name for a <see cref="PInvoke.EventTraceGuid" /> event and, when the name
+    ///     is <c>"DbgIdRSDS"</c>, forwards the record to <see cref="HandleKernelDbgIdRsds" />.
+    ///     This mirrors the name-based detection in the original <c>#if FIXME</c> block inside
+    ///     <see cref="Deserializer{T}" />.
+    /// </summary>
+    private unsafe void TryHandleMsntDbgIdRsdsViaTdh(EventRecordReader reader, EVENT_RECORD* eventRecord)
+    {
+        uint bufferSize = 0;
+        uint ret = PInvoke.TdhGetEventInformation(eventRecord, 0, null, null, &bufferSize);
+
+        if (ret != (uint)WIN32_ERROR.ERROR_INSUFFICIENT_BUFFER)
+        {
+            return;
+        }
+
+        TRACE_EVENT_INFO* info = (TRACE_EVENT_INFO*)Marshal.AllocHGlobal((int)bufferSize);
+        try
+        {
+            ret = PInvoke.TdhGetEventInformation(eventRecord, 0, null, info, &bufferSize);
+            if (ret != 0 || info->OpcodeNameOffset == 0)
+            {
+                return;
+            }
+
+            string opcodeName = new((char*)((byte*)info + info->OpcodeNameOffset));
+            if (!opcodeName.Equals("DbgIdRSDS", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            HandleKernelDbgIdRsds(reader, eventRecord);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal((IntPtr)info);
         }
     }
 

--- a/src/Deserializer/WPP/PdbMetaData.cs
+++ b/src/Deserializer/WPP/PdbMetaData.cs
@@ -7,7 +7,7 @@ namespace Nefarius.Utilities.ETW.Deserializer.WPP;
 /// </summary>
 [SuppressMessage("ReSharper", "UnusedMember.Global")]
 [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-public readonly struct PdbMetaData
+public readonly struct PdbMetaData : IEquatable<PdbMetaData>
 {
     /// <summary>
     ///     The full path of the PDB extracted from the session information.
@@ -48,4 +48,21 @@ public readonly struct PdbMetaData
     ///     Gets the typical symbol server download path.
     /// </summary>
     public string DownloadPath => $"/download/symbols/{IndexPrefix}";
+
+    /// <inheritdoc />
+    public bool Equals(PdbMetaData other) =>
+        Guid == other.Guid && Age == other.Age &&
+        string.Equals(PdbName, other.PdbName, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is PdbMetaData other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(Guid, Age, PdbName?.ToLowerInvariant());
+
+    /// <inheritdoc />
+    public static bool operator ==(PdbMetaData left, PdbMetaData right) => left.Equals(right);
+
+    /// <inheritdoc />
+    public static bool operator !=(PdbMetaData left, PdbMetaData right) => !left.Equals(right);
 }

--- a/src/Deserializer/WPP/PdbMetaData.cs
+++ b/src/Deserializer/WPP/PdbMetaData.cs
@@ -52,13 +52,17 @@ public readonly struct PdbMetaData : IEquatable<PdbMetaData>
     /// <inheritdoc />
     public bool Equals(PdbMetaData other) =>
         Guid == other.Guid && Age == other.Age &&
-        string.Equals(PdbName, other.PdbName, StringComparison.OrdinalIgnoreCase);
+        string.Equals(
+            Path.GetFileName(PdbName),
+            Path.GetFileName(other.PdbName),
+            StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
     public override bool Equals(object? obj) => obj is PdbMetaData other && Equals(other);
 
     /// <inheritdoc />
-    public override int GetHashCode() => HashCode.Combine(Guid, Age, PdbName?.ToLowerInvariant());
+    public override int GetHashCode() =>
+        HashCode.Combine(Guid, Age, Path.GetFileName(PdbName)?.ToLowerInvariant());
 
     /// <inheritdoc />
     public static bool operator ==(PdbMetaData left, PdbMetaData right) => left.Equals(right);

--- a/src/Deserializer/WPP/PdbMetaData.cs
+++ b/src/Deserializer/WPP/PdbMetaData.cs
@@ -62,7 +62,10 @@ public readonly struct PdbMetaData : IEquatable<PdbMetaData>
 
     /// <inheritdoc />
     public override int GetHashCode() =>
-        HashCode.Combine(Guid, Age, Path.GetFileName(PdbName)?.ToLowerInvariant());
+        HashCode.Combine(
+            Guid,
+            Age,
+            StringComparer.OrdinalIgnoreCase.GetHashCode(Path.GetFileName(PdbName) ?? string.Empty));
 
     /// <inheritdoc />
     public static bool operator ==(PdbMetaData left, PdbMetaData right) => left.Equals(right);

--- a/src/EtwJsonConverterOptions.cs
+++ b/src/EtwJsonConverterOptions.cs
@@ -22,12 +22,14 @@ public sealed class EtwJsonConverterOptions
     /// <summary>
     ///     <see cref="DecodingContext" /> to read WPP events.
     /// </summary>
+    /// <remarks>
+    ///     Build this context by calling <see cref="EtwUtil.EnumeratePdbReferences" /> first to discover all PDB
+    ///     references in the trace, resolve each <see cref="PdbMetaData" /> to its actual <c>.pdb</c> file, then
+    ///     construct a <see cref="DecodingContext" /> from the resulting
+    ///     <see cref="PdbFileDecodingContextType" /> (or <see cref="TmfFilesDirectoryDecodingContextType" />) instances
+    ///     before calling <see cref="EtwUtil.ConvertToJson" />.
+    /// </remarks>
     public DecodingContext? WppDecodingContext { get; set; }
-
-    /// <summary>
-    ///     Custom <see cref="DecodingContext" /> provider lookup.
-    /// </summary>
-    public Func<PdbMetaData, DecodingContextType?>? ContextProviderLookup { get; set; }
 
     /// <summary>
     ///     If set, <c>PROCESS_TRACE_MODE_RAW_TIMESTAMP</c> will be applied when processing the trace record.

--- a/src/EtwMetadataScanOptions.cs
+++ b/src/EtwMetadataScanOptions.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics.CodeAnalysis;
+
+using Nefarius.Utilities.ETW.Events;
+
+namespace Nefarius.Utilities.ETW;
+
+/// <summary>
+///     Adjustments for <see cref="EtwUtil.EnumeratePdbReferences" />.
+/// </summary>
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+public sealed class EtwMetadataScanOptions
+{
+    internal EtwMetadataScanOptions() { }
+
+    /// <summary>
+    ///     Reports potential scanning errors.
+    /// </summary>
+    public Action<string>? ReportError { get; set; }
+
+    /// <summary>
+    ///     Invoked for every <c>KernelTraceControl/ImageID/DbgID_RSDS</c> event (opcode 36, provider
+    ///     <c>b3e675d7-2554-4f18-830b-2762732560de</c>) encountered in the trace.
+    /// </summary>
+    /// <remarks>
+    ///     Each such event identifies a PDB that was used to instrument the code being traced.
+    ///     The <see cref="DbgIdRsdsEventInfo.ToPdbMetaData" /> helper projects the event into the
+    ///     <see cref="Deserializer.WPP.PdbMetaData" /> shape expected by
+    ///     <see cref="EtwJsonConverterOptions.WppDecodingContext" />.
+    /// </remarks>
+    public Action<DbgIdRsdsEventInfo>? OnDbgIdRsds { get; set; }
+
+    /// <summary>
+    ///     Invoked for every <c>KernelTraceControl/ImageID</c> event (opcode 0, provider
+    ///     <c>b3e675d7-2554-4f18-830b-2762732560de</c>) encountered in the trace.
+    /// </summary>
+    /// <remarks>
+    ///     These events carry the base address, size, and original file name of a loaded image.
+    /// </remarks>
+    public Action<ImageIdEventInfo>? OnImageId { get; set; }
+
+    /// <summary>
+    ///     Invoked for every <c>KernelTraceControl/ImageID/FileVersion</c> event (opcode 64, provider
+    ///     <c>b3e675d7-2554-4f18-830b-2762732560de</c>) encountered in the trace.
+    /// </summary>
+    /// <remarks>
+    ///     These events carry the version-resource strings of a loaded image.
+    /// </remarks>
+    public Action<ImageIdFileVersionEventInfo>? OnImageIdFileVersion { get; set; }
+
+    /// <summary>
+    ///     Invoked for every <c>MSNT_SystemTrace/EventTrace/DbgIdRSDS</c> event emitted by the legacy kernel Event Trace
+    ///     provider (<c>EventTraceGuid</c>) encountered in the trace.
+    /// </summary>
+    public Action<KernelDbgIdRsdsEventInfo>? OnKernelDbgIdRsds { get; set; }
+}

--- a/src/EtwUtil.cs
+++ b/src/EtwUtil.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Windows.Win32.Foundation;
 
 using Nefarius.Utilities.ETW.Deserializer;
+using Nefarius.Utilities.ETW.Deserializer.WPP;
 
 namespace Nefarius.Utilities.ETW;
 
@@ -14,6 +15,28 @@ namespace Nefarius.Utilities.ETW;
 [SuppressMessage("ReSharper", "UnusedMember.Global")]
 public static class EtwUtil
 {
+    /// <summary>
+    ///     Performs a lightweight pre-scan of one or more <c>.ETL</c> files and returns the deduplicated set of
+    ///     <see cref="PdbMetaData" /> entries discovered in the trace's image-ID events.
+    /// </summary>
+    /// <param name="inputFiles">One or more input <c>.etl</c> files to scan.</param>
+    /// <param name="options">Optional callback to configure scan behaviour and subscribe to image-ID event notifications.</param>
+    /// <returns>
+    ///     A deduplicated, read-only collection of every <see cref="PdbMetaData" /> referenced by the trace.
+    ///     The caller should use these entries to locate or download the corresponding <c>.pdb</c> files, then pass the
+    ///     resulting <see cref="Deserializer.WPP.DecodingContext" /> to
+    ///     <see cref="ConvertToJson" /> via <see cref="EtwJsonConverterOptions.WppDecodingContext" />.
+    /// </returns>
+    public static IReadOnlyCollection<PdbMetaData> EnumeratePdbReferences(IEnumerable<string> inputFiles,
+        Action<EtwMetadataScanOptions>? options = null)
+    {
+        EtwMetadataScanOptions opts = new();
+        options?.Invoke(opts);
+
+        MetadataScanner scanner = new(opts);
+        return scanner.Scan(inputFiles.ToList());
+    }
+
     /// <summary>
     ///     Converts one or more .ETL files to a JSON object.
     /// </summary>
@@ -32,8 +55,7 @@ public static class EtwUtil
         Deserializer<EtwJsonWriter> deserializer = new(
             new EtwJsonWriter(jsonWriter),
             opts.CustomProviderManifest,
-            opts.WppDecodingContext,
-            opts.ContextProviderLookup
+            opts.WppDecodingContext
         );
 
         int count = list.Count;

--- a/src/EtwUtil.cs
+++ b/src/EtwUtil.cs
@@ -17,24 +17,50 @@ public static class EtwUtil
 {
     /// <summary>
     ///     Performs a lightweight pre-scan of one or more <c>.ETL</c> files and returns the deduplicated set of
-    ///     <see cref="PdbMetaData" /> entries discovered in the trace's image-ID events.
+    ///     <see cref="PdbMetaData" /> entries discovered in the trace.
     /// </summary>
-    /// <param name="inputFiles">One or more input <c>.etl</c> files to scan.</param>
-    /// <param name="options">Optional callback to configure scan behaviour and subscribe to image-ID event notifications.</param>
+    /// <param name="inputFiles">
+    ///     One or more input <c>.etl</c> files to scan. Must not be <see langword="null" /> and must not
+    ///     contain any <see langword="null" /> or whitespace-only entries.
+    /// </param>
+    /// <param name="options">
+    ///     Optional callback to configure scan behaviour. Use it to subscribe to
+    ///     <see cref="EtwMetadataScanOptions.OnDbgIdRsds" /> (<c>KernelTraceControl/ImageID/DbgID_RSDS</c>),
+    ///     <see cref="EtwMetadataScanOptions.OnKernelDbgIdRsds" /> (<c>MSNT_SystemTrace/EventTrace/DbgIdRSDS</c>),
+    ///     <see cref="EtwMetadataScanOptions.OnImageId" /> (<c>KernelTraceControl/ImageID</c>), and
+    ///     <see cref="EtwMetadataScanOptions.OnImageIdFileVersion" /> (<c>KernelTraceControl/ImageID/FileVersion</c>)
+    ///     event notifications, or to provide a <see cref="EtwMetadataScanOptions.ReportError" /> handler.
+    /// </param>
     /// <returns>
     ///     A deduplicated, read-only collection of every <see cref="PdbMetaData" /> referenced by the trace.
-    ///     The caller should use these entries to locate or download the corresponding <c>.pdb</c> files, then pass the
-    ///     resulting <see cref="Deserializer.WPP.DecodingContext" /> to
+    ///     The caller should use these entries to locate or download the corresponding <c>.pdb</c> files (or find
+    ///     matching <c>.tmf</c> files), then pass the resulting <see cref="Deserializer.WPP.DecodingContext" /> to
     ///     <see cref="ConvertToJson" /> via <see cref="EtwJsonConverterOptions.WppDecodingContext" />.
     /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="inputFiles" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">
+    ///     One or more entries in <paramref name="inputFiles" /> are <see langword="null" />, empty, or consist only of
+    ///     whitespace.
+    /// </exception>
     public static IReadOnlyCollection<PdbMetaData> EnumeratePdbReferences(IEnumerable<string> inputFiles,
         Action<EtwMetadataScanOptions>? options = null)
     {
+        ArgumentNullException.ThrowIfNull(inputFiles);
+
+        List<string> list = inputFiles.ToList();
+        for (int i = 0; i < list.Count; i++)
+        {
+            if (string.IsNullOrWhiteSpace(list[i]))
+            {
+                throw new ArgumentException($"Entry at index {i} is null, empty, or whitespace.", nameof(inputFiles));
+            }
+        }
+
         EtwMetadataScanOptions opts = new();
         options?.Invoke(opts);
 
         MetadataScanner scanner = new(opts);
-        return scanner.Scan(inputFiles.ToList());
+        return scanner.Scan(list);
     }
 
     /// <summary>

--- a/src/Events/DbgIdRsdsEventInfo.cs
+++ b/src/Events/DbgIdRsdsEventInfo.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.CodeAnalysis;
+
+using Nefarius.Utilities.ETW.Deserializer.WPP;
+
+namespace Nefarius.Utilities.ETW.Events;
+
+/// <summary>
+///     Strongly-typed representation of a <c>KernelTraceControl/ImageID/DbgID_RSDS</c> event (opcode 36,
+///     provider <c>b3e675d7-2554-4f18-830b-2762732560de</c>).
+/// </summary>
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+public readonly record struct DbgIdRsdsEventInfo
+{
+    /// <summary>Raw event timestamp (100-nanosecond intervals since January 1, 1601).</summary>
+    public long Timestamp { get; init; }
+
+    /// <summary>Process ID of the process that logged the event.</summary>
+    public uint ProcessId { get; init; }
+
+    /// <summary>Thread ID of the thread that logged the event.</summary>
+    public uint ThreadId { get; init; }
+
+    /// <summary>Base address of the image at the time the debug information was recorded.</summary>
+    public ulong ImageBase { get; init; }
+
+    /// <summary>The GUID embedded in the PDB that uniquely identifies the symbol file.</summary>
+    public Guid GuidSig { get; init; }
+
+    /// <summary>PDB age (revision counter).</summary>
+    public uint Age { get; init; }
+
+    /// <summary>Original file name of the PDB (may be a full path recorded at build time).</summary>
+    public string PdbFileName { get; init; }
+
+    /// <summary>Projects this event into the <see cref="PdbMetaData" /> structure used for symbol server lookups.</summary>
+    public PdbMetaData ToPdbMetaData() => new() { Guid = GuidSig, Age = (int)Age, PdbName = PdbFileName };
+}

--- a/src/Events/DbgIdRsdsEventInfo.cs
+++ b/src/Events/DbgIdRsdsEventInfo.cs
@@ -34,5 +34,17 @@ public readonly record struct DbgIdRsdsEventInfo
     public string PdbFileName { get; init; }
 
     /// <summary>Projects this event into the <see cref="PdbMetaData" /> structure used for symbol server lookups.</summary>
-    public PdbMetaData ToPdbMetaData() => new() { Guid = GuidSig, Age = (int)Age, PdbName = PdbFileName };
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///     Thrown when <see cref="Age" /> exceeds <see cref="int.MaxValue" /> and cannot be safely narrowed.
+    /// </exception>
+    public PdbMetaData ToPdbMetaData()
+    {
+        if (Age > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(nameof(Age), Age,
+                $"PDB age value {Age} exceeds Int32.MaxValue and cannot be stored in PdbMetaData.");
+        }
+
+        return new PdbMetaData { Guid = GuidSig, Age = (int)Age, PdbName = PdbFileName };
+    }
 }

--- a/src/Events/ImageIdEventInfo.cs
+++ b/src/Events/ImageIdEventInfo.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nefarius.Utilities.ETW.Events;
+
+/// <summary>
+///     Strongly-typed representation of a <c>KernelTraceControl/ImageID</c> event (opcode 0,
+///     provider <c>b3e675d7-2554-4f18-830b-2762732560de</c>).
+/// </summary>
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+public readonly record struct ImageIdEventInfo
+{
+    /// <summary>Raw event timestamp (100-nanosecond intervals since January 1, 1601).</summary>
+    public long Timestamp { get; init; }
+
+    /// <summary>Process ID of the process that logged the event.</summary>
+    public uint ProcessId { get; init; }
+
+    /// <summary>Thread ID of the thread that logged the event.</summary>
+    public uint ThreadId { get; init; }
+
+    /// <summary>Base virtual address at which the image was loaded.</summary>
+    public ulong ImageBase { get; init; }
+
+    /// <summary>Size of the image in bytes.</summary>
+    public uint ImageSize { get; init; }
+
+    /// <summary>PE timestamp / date-stamp from the image header.</summary>
+    public uint TimeDateStamp { get; init; }
+
+    /// <summary>Original file name of the image as recorded in the trace.</summary>
+    public string OriginalFileName { get; init; }
+}

--- a/src/Events/ImageIdFileVersionEventInfo.cs
+++ b/src/Events/ImageIdFileVersionEventInfo.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nefarius.Utilities.ETW.Events;
+
+/// <summary>
+///     Strongly-typed representation of a <c>KernelTraceControl/ImageID/FileVersion</c> event (opcode 64,
+///     provider <c>b3e675d7-2554-4f18-830b-2762732560de</c>).
+/// </summary>
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+public readonly record struct ImageIdFileVersionEventInfo
+{
+    /// <summary>Raw event timestamp (100-nanosecond intervals since January 1, 1601).</summary>
+    public long Timestamp { get; init; }
+
+    /// <summary>Process ID of the process that logged the event.</summary>
+    public uint ProcessId { get; init; }
+
+    /// <summary>Thread ID of the thread that logged the event.</summary>
+    public uint ThreadId { get; init; }
+
+    /// <summary>Size of the image in bytes.</summary>
+    public uint ImageSize { get; init; }
+
+    /// <summary>PE timestamp / date-stamp from the image header.</summary>
+    public uint TimeDateStamp { get; init; }
+
+    /// <summary>Original file name of the image.</summary>
+    public string OrigFileName { get; init; }
+
+    /// <summary>Human-readable file description from the version resource.</summary>
+    public string FileDescription { get; init; }
+
+    /// <summary>File version string from the version resource.</summary>
+    public string FileVersion { get; init; }
+
+    /// <summary>Binary (numeric) file version from the version resource.</summary>
+    public string BinFileVersion { get; init; }
+
+    /// <summary>Language identifier of the version resource.</summary>
+    public string VerLanguage { get; init; }
+
+    /// <summary>Product name from the version resource.</summary>
+    public string ProductName { get; init; }
+
+    /// <summary>Company name from the version resource.</summary>
+    public string CompanyName { get; init; }
+
+    /// <summary>Product version string from the version resource.</summary>
+    public string ProductVersion { get; init; }
+
+    /// <summary>File identifier.</summary>
+    public string FileId { get; init; }
+
+    /// <summary>Program identifier.</summary>
+    public string ProgramId { get; init; }
+}

--- a/src/Events/KernelDbgIdRsdsEventInfo.cs
+++ b/src/Events/KernelDbgIdRsdsEventInfo.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics.CodeAnalysis;
+
+using Nefarius.Utilities.ETW.Deserializer.WPP;
+
+namespace Nefarius.Utilities.ETW.Events;
+
+/// <summary>
+///     Strongly-typed representation of a <c>MSNT_SystemTrace/EventTrace/DbgIdRSDS</c> event emitted by the
+///     legacy kernel Event Trace provider (<see cref="PInvoke.EventTraceGuid" />).
+/// </summary>
+/// <remarks>
+///     The layout of this event is: <c>Guid</c> (16 bytes) + <c>Age</c> (uint32) + null-terminated ANSI PDB name.
+///     This is distinct from the <see cref="DbgIdRsdsEventInfo" /> emitted by the
+///     <c>KernelTraceControl/ImageID</c> provider, which prepends <c>ImageBase</c> and <c>ProcessId</c>.
+/// </remarks>
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+public readonly record struct KernelDbgIdRsdsEventInfo
+{
+    /// <summary>Raw event timestamp (100-nanosecond intervals since January 1, 1601).</summary>
+    public long Timestamp { get; init; }
+
+    /// <summary>Process ID of the process that logged the event.</summary>
+    public uint ProcessId { get; init; }
+
+    /// <summary>Thread ID of the thread that logged the event.</summary>
+    public uint ThreadId { get; init; }
+
+    /// <summary>The GUID embedded in the PDB that uniquely identifies the symbol file.</summary>
+    public Guid Guid { get; init; }
+
+    /// <summary>PDB age (revision counter).</summary>
+    public uint Age { get; init; }
+
+    /// <summary>Original file name of the PDB (may be a full path recorded at build time).</summary>
+    public string PdbName { get; init; }
+
+    /// <summary>Projects this event into the <see cref="PdbMetaData" /> structure used for symbol server lookups.</summary>
+    public PdbMetaData ToPdbMetaData() => new() { Guid = Guid, Age = (int)Age, PdbName = PdbName };
+}

--- a/src/Events/KernelDbgIdRsdsEventInfo.cs
+++ b/src/Events/KernelDbgIdRsdsEventInfo.cs
@@ -36,5 +36,17 @@ public readonly record struct KernelDbgIdRsdsEventInfo
     public string PdbName { get; init; }
 
     /// <summary>Projects this event into the <see cref="PdbMetaData" /> structure used for symbol server lookups.</summary>
-    public PdbMetaData ToPdbMetaData() => new() { Guid = Guid, Age = (int)Age, PdbName = PdbName };
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///     Thrown when <see cref="Age" /> exceeds <see cref="int.MaxValue" /> and cannot be safely narrowed.
+    /// </exception>
+    public PdbMetaData ToPdbMetaData()
+    {
+        if (Age > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(nameof(Age), Age,
+                $"PDB age value {Age} exceeds Int32.MaxValue and cannot be stored in PdbMetaData.");
+        }
+
+        return new PdbMetaData { Guid = Guid, Age = (int)Age, PdbName = PdbName };
+    }
 }

--- a/tests/UnitTestParser.cs
+++ b/tests/UnitTestParser.cs
@@ -140,9 +140,14 @@ public class Tests
         services.AddHttpClient();
         ServiceProvider provider = services.BuildServiceProvider();
 
+        bool isCI = string.Equals(Environment.GetEnvironmentVariable("CI"), "true",
+            StringComparison.OrdinalIgnoreCase);
+
         IHttpClientFactory factory = provider.GetRequiredService<IHttpClientFactory>();
         HttpClient client = factory.CreateClient();
-        client.BaseAddress = new Uri("http://192.168.2.12:5000");
+        client.BaseAddress = isCI
+            ? new Uri("https://symbols.nefarius.at/")
+            : new Uri("http://192.168.2.12:5000");
         client.Timeout = TimeSpan.FromSeconds(30);
 
         // Pass 1: collect all PDB references embedded in the trace.

--- a/tests/UnitTestParser.cs
+++ b/tests/UnitTestParser.cs
@@ -132,8 +132,14 @@ public class Tests
     }
 
     [Test]
+    [Category("Integration")]
     public async Task SymbolServerDownloadTest()
     {
+        if (!string.Equals(Environment.GetEnvironmentVariable("RUN_INTEGRATION_TESTS"), "true",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.Ignore("Set RUN_INTEGRATION_TESTS=true to run integration tests.");
+        }
         const string etwFilePath = @".\traces\BthPS3_0.etl";
 
         ServiceCollection services = new();
@@ -181,7 +187,7 @@ public class Tests
 
         ms.Seek(0, SeekOrigin.Begin);
 
-        await using FileStream outFile = File.OpenWrite("BthPS3_0_server.json");
+        await using FileStream outFile = File.Create("BthPS3_0_server.json");
         await ms.CopyToAsync(outFile, cts.Token).ConfigureAwait(false);
 
         Assert.Pass();

--- a/tests/UnitTestParser.cs
+++ b/tests/UnitTestParser.cs
@@ -139,15 +139,9 @@ public class Tests
         ServiceCollection services = new();
         services.AddHttpClient();
         ServiceProvider provider = services.BuildServiceProvider();
-
-        bool isCI = string.Equals(Environment.GetEnvironmentVariable("CI"), "true",
-            StringComparison.OrdinalIgnoreCase);
-
         IHttpClientFactory factory = provider.GetRequiredService<IHttpClientFactory>();
         HttpClient client = factory.CreateClient();
-        client.BaseAddress = isCI
-            ? new Uri("https://symbols.nefarius.at/")
-            : new Uri("http://192.168.2.12:5000");
+        client.BaseAddress = new Uri("https://symbols.nefarius.at/");
         client.Timeout = TimeSpan.FromSeconds(30);
 
         // Pass 1: collect all PDB references embedded in the trace.
@@ -156,7 +150,7 @@ public class Tests
         // Pass 2: resolve each PDB from the symbol server and build a DecodingContext.
         using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
 
-        List<DecodingContextType> decodingTypes = new();
+        List<DecodingContextType> decodingTypes = [];
         foreach (PdbMetaData pdbMetaData in pdbRefs)
         {
             using HttpResponseMessage response =
@@ -171,11 +165,11 @@ public class Tests
 
         DecodingContext decodingContext = new(decodingTypes);
 
-        // Pass 3: decode the trace with the fully-assembled context.
+        // Pass 3: decode the trace with the fully assembled context.
         JsonWriterOptions options = new() { Indented = true };
 
         using MemoryStream ms = new();
-        using Utf8JsonWriter jsonWriter = new(ms, options);
+        await using Utf8JsonWriter jsonWriter = new(ms, options);
 
         if (!EtwUtil.ConvertToJson(jsonWriter, [etwFilePath], converterOptions =>
             {
@@ -187,8 +181,8 @@ public class Tests
 
         ms.Seek(0, SeekOrigin.Begin);
 
-        using FileStream outFile = File.OpenWrite("BthPS3_0_server.json");
-        await ms.CopyToAsync(outFile).ConfigureAwait(false);
+        await using FileStream outFile = File.OpenWrite("BthPS3_0_server.json");
+        await ms.CopyToAsync(outFile, cts.Token).ConfigureAwait(false);
 
         Assert.Pass();
     }
@@ -207,7 +201,7 @@ public class Tests
         // The BthPS3 trace must reference at least BthPS3.pdb and BthPS3PSM.pdb.
         Assert.That(refs, Is.Not.Empty);
 
-        IEnumerable<string> pdbNames = refs.Select(r => Path.GetFileName(r.PdbName).ToLowerInvariant());
+        IList<string> pdbNames = refs.Select(r => Path.GetFileName(r.PdbName).ToLowerInvariant()).ToList();
         Assert.That(pdbNames, Does.Contain("bthps3.pdb"));
         Assert.That(pdbNames, Does.Contain("bthps3psm.pdb"));
     }

--- a/tests/UnitTestParser.cs
+++ b/tests/UnitTestParser.cs
@@ -132,7 +132,7 @@ public class Tests
     }
 
     [Test]
-    public void SymbolServerDownloadTest()
+    public async Task SymbolServerDownloadTest()
     {
         const string etwFilePath = @".\traces\BthPS3_0.etl";
 
@@ -143,22 +143,26 @@ public class Tests
         IHttpClientFactory factory = provider.GetRequiredService<IHttpClientFactory>();
         HttpClient client = factory.CreateClient();
         client.BaseAddress = new Uri("http://192.168.2.12:5000");
+        client.Timeout = TimeSpan.FromSeconds(30);
 
         // Pass 1: collect all PDB references embedded in the trace.
         IReadOnlyCollection<PdbMetaData> pdbRefs = EtwUtil.EnumeratePdbReferences([etwFilePath]);
 
         // Pass 2: resolve each PDB from the symbol server and build a DecodingContext.
-        List<DecodingContextType> decodingTypes = pdbRefs
-            .Select(pdbMetaData =>
-            {
-                using Stream webStream = client.GetStreamAsync(pdbMetaData.DownloadPath).GetAwaiter().GetResult();
-                using MemoryStream memory = new();
-                // web streams are not seekable, so buffer into memory first
-                webStream.CopyTo(memory);
-                memory.Position = 0;
-                return (DecodingContextType)new PdbFileDecodingContextType(memory);
-            })
-            .ToList();
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
+
+        List<DecodingContextType> decodingTypes = new();
+        foreach (PdbMetaData pdbMetaData in pdbRefs)
+        {
+            HttpResponseMessage response =
+                await client.GetAsync(pdbMetaData.DownloadPath, cts.Token).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            using MemoryStream memory = new();
+            await response.Content.CopyToAsync(memory, cts.Token).ConfigureAwait(false);
+            memory.Position = 0;
+            decodingTypes.Add(new PdbFileDecodingContextType(memory));
+        }
 
         DecodingContext decodingContext = new(decodingTypes);
 
@@ -179,7 +183,7 @@ public class Tests
         ms.Seek(0, SeekOrigin.Begin);
 
         using FileStream outFile = File.OpenWrite("BthPS3_0_server.json");
-        ms.CopyTo(outFile);
+        await ms.CopyToAsync(outFile).ConfigureAwait(false);
 
         Assert.Pass();
     }

--- a/tests/UnitTestParser.cs
+++ b/tests/UnitTestParser.cs
@@ -154,7 +154,7 @@ public class Tests
         List<DecodingContextType> decodingTypes = new();
         foreach (PdbMetaData pdbMetaData in pdbRefs)
         {
-            HttpResponseMessage response =
+            using HttpResponseMessage response =
                 await client.GetAsync(pdbMetaData.DownloadPath, cts.Token).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 

--- a/tests/UnitTestParser.cs
+++ b/tests/UnitTestParser.cs
@@ -136,11 +136,6 @@ public class Tests
     {
         const string etwFilePath = @".\traces\BthPS3_0.etl";
 
-        JsonWriterOptions options = new() { Indented = true };
-
-        using MemoryStream ms = new();
-        using Utf8JsonWriter jsonWriter = new(ms, options);
-
         ServiceCollection services = new();
         services.AddHttpClient();
         ServiceProvider provider = services.BuildServiceProvider();
@@ -149,18 +144,33 @@ public class Tests
         HttpClient client = factory.CreateClient();
         client.BaseAddress = new Uri("http://192.168.2.12:5000");
 
+        // Pass 1: collect all PDB references embedded in the trace.
+        IReadOnlyCollection<PdbMetaData> pdbRefs = EtwUtil.EnumeratePdbReferences([etwFilePath]);
+
+        // Pass 2: resolve each PDB from the symbol server and build a DecodingContext.
+        List<DecodingContextType> decodingTypes = pdbRefs
+            .Select(pdbMetaData =>
+            {
+                using Stream webStream = client.GetStreamAsync(pdbMetaData.DownloadPath).GetAwaiter().GetResult();
+                using MemoryStream memory = new();
+                // web streams are not seekable, so buffer into memory first
+                webStream.CopyTo(memory);
+                memory.Position = 0;
+                return (DecodingContextType)new PdbFileDecodingContextType(memory);
+            })
+            .ToList();
+
+        DecodingContext decodingContext = new(decodingTypes);
+
+        // Pass 3: decode the trace with the fully-assembled context.
+        JsonWriterOptions options = new() { Indented = true };
+
+        using MemoryStream ms = new();
+        using Utf8JsonWriter jsonWriter = new(ms, options);
+
         if (!EtwUtil.ConvertToJson(jsonWriter, [etwFilePath], converterOptions =>
             {
-                converterOptions.ContextProviderLookup = pdbMetaData =>
-                {
-                    using Stream webStream = client.GetStreamAsync(pdbMetaData.DownloadPath).GetAwaiter().GetResult();
-                    using MemoryStream memory = new();
-                    // we cannot seek a web stream, so we need to cache it in memory first
-                    webStream.CopyTo(memory);
-                    memory.Position = 0;
-
-                    return new PdbFileDecodingContextType(memory);
-                };
+                converterOptions.WppDecodingContext = decodingContext;
             }))
         {
             Assert.Fail();
@@ -172,6 +182,25 @@ public class Tests
         ms.CopyTo(outFile);
 
         Assert.Pass();
+    }
+
+    /// <summary>
+    ///     Verifies that <see cref="EtwUtil.EnumeratePdbReferences" /> correctly discovers the PDB references
+    ///     embedded in the BthPS3 trace without performing a full decode.
+    /// </summary>
+    [Test]
+    public void EnumeratePdbReferencesTest()
+    {
+        const string etwFilePath = @".\traces\BthPS3_0.etl";
+
+        IReadOnlyCollection<PdbMetaData> refs = EtwUtil.EnumeratePdbReferences([etwFilePath]);
+
+        // The BthPS3 trace must reference at least BthPS3.pdb and BthPS3PSM.pdb.
+        Assert.That(refs, Is.Not.Empty);
+
+        IEnumerable<string> pdbNames = refs.Select(r => Path.GetFileName(r.PdbName).ToLowerInvariant());
+        Assert.That(pdbNames, Does.Contain("bthps3.pdb"));
+        Assert.That(pdbNames, Does.Contain("bthps3psm.pdb"));
     }
 
     [Test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ETL pre-scan added to enumerate referenced PDB metadata for reliable multi‑PDB symbol resolution.

* **Documentation**
  * README and docs updated with guidance on using pre-scan results to build a decoding context for conversion; removed obsolete per‑PDB lookup doc.

* **Breaking Changes**
  * Automatic per‑PDB lookup removed; decoding contexts must be provided up‑front.

* **Tests**
  * Tests added/updated to validate PDB enumeration and integration decoding.

* **Chores**
  * CI now runs on Windows and publishes test results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/Nefarius.Utilities.ETW/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->