### PR TITLE
Added Async Enumerables support

### DIFF
--- a/src/EtwJsonChannelWriter.cs
+++ b/src/EtwJsonChannelWriter.cs
@@ -1,0 +1,225 @@
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading.Channels;
+
+using Nefarius.Utilities.ETW.Deserializer;
+
+namespace Nefarius.Utilities.ETW;
+
+/// <summary>
+///     Carries a single decoded ETW event as a pooled UTF-8 JSON byte buffer.
+/// </summary>
+internal readonly struct PooledEventBuffer
+{
+    internal readonly byte[] Rented;
+    internal readonly int Length;
+
+    internal PooledEventBuffer(byte[] rented, int length)
+    {
+        Rented = rented;
+        Length = length;
+    }
+
+    internal ReadOnlyMemory<byte> Memory => new(Rented, 0, Length);
+}
+
+/// <summary>
+///     An <see cref="IEtwWriter" /> implementation that serializes each ETW event into a pooled
+///     UTF-8 JSON buffer and writes the completed buffer into a bounded channel.
+/// </summary>
+internal sealed class EtwJsonChannelWriter : IEtwWriter
+{
+    private readonly ArrayBufferWriter<byte> _bufferWriter = new(initialCapacity: 4096);
+    private readonly ChannelWriter<PooledEventBuffer> _channelWriter;
+    private readonly CancellationToken _cancellationToken;
+    private Utf8JsonWriter _jsonWriter;
+
+    internal EtwJsonChannelWriter(ChannelWriter<PooledEventBuffer> channelWriter,
+        CancellationToken cancellationToken = default,
+        JsonWriterOptions writerOptions = default)
+    {
+        _channelWriter = channelWriter;
+        _cancellationToken = cancellationToken;
+        _jsonWriter = new Utf8JsonWriter(_bufferWriter, writerOptions);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public void WriteEventBegin(EventMetadata metadata, RuntimeEventMetadata runtimeMetadata)
+    {
+        _bufferWriter.Clear();
+        _jsonWriter.Reset(_bufferWriter);
+
+        _jsonWriter.WriteStartObject();
+        _jsonWriter.WritePropertyName("Event");
+        _jsonWriter.WriteStartObject();
+
+        _jsonWriter.WritePropertyName("Timestamp");
+        _jsonWriter.WriteNumberValue(runtimeMetadata.Timestamp);
+
+        _jsonWriter.WritePropertyName("ProviderGuid");
+        _jsonWriter.WriteStringValue(metadata.ProviderGuid.ToString("D"));
+
+        _jsonWriter.WritePropertyName("Id");
+        _jsonWriter.WriteNumberValue(metadata.Id);
+
+        _jsonWriter.WritePropertyName("Version");
+        _jsonWriter.WriteNumberValue(metadata.Version);
+
+        _jsonWriter.WritePropertyName("ProcessId");
+        _jsonWriter.WriteNumberValue(runtimeMetadata.ProcessId);
+
+        _jsonWriter.WritePropertyName("ThreadId");
+        _jsonWriter.WriteNumberValue(runtimeMetadata.ThreadId);
+
+        _jsonWriter.WritePropertyName("ProcessorNumber");
+        _jsonWriter.WriteNumberValue(runtimeMetadata.ProcessorNumber);
+
+        Guid activityId = runtimeMetadata.ActivityId;
+        if (activityId != Guid.Empty)
+        {
+            _jsonWriter.WritePropertyName("ActivityId");
+            _jsonWriter.WriteStringValue(activityId.ToString("D"));
+        }
+
+        Guid relatedActivityId = runtimeMetadata.RelatedActivityId;
+        if (relatedActivityId != Guid.Empty)
+        {
+            _jsonWriter.WritePropertyName("RelatedActivityId");
+            _jsonWriter.WriteStringValue(relatedActivityId.ToString("D"));
+        }
+
+        ulong[]? stacks = runtimeMetadata.GetStacks(out ulong matchId);
+        if (matchId != 0)
+        {
+            _jsonWriter.WritePropertyName("StackMatchId");
+            _jsonWriter.WriteNumberValue(matchId);
+        }
+
+        if (stacks != null)
+        {
+            _jsonWriter.WritePropertyName("Stacks");
+            _jsonWriter.WriteStartArray();
+            for (int i = 0; i < stacks.Length; ++i)
+            {
+                _jsonWriter.WriteNumberValue(stacks[i]);
+            }
+
+            _jsonWriter.WriteEndArray();
+        }
+
+        _jsonWriter.WritePropertyName("Name");
+        _jsonWriter.WriteStringValue(metadata.Name);
+
+        _jsonWriter.WritePropertyName("Properties");
+        _jsonWriter.WriteStartArray();
+        _jsonWriter.WriteStartObject();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteEventEnd()
+    {
+        _jsonWriter.WriteEndObject();
+        _jsonWriter.WriteEndArray();
+        _jsonWriter.WriteEndObject();
+        _jsonWriter.WriteEndObject();
+        _jsonWriter.Flush();
+
+        int length = _bufferWriter.WrittenCount;
+        byte[] rented = ArrayPool<byte>.Shared.Rent(length);
+        _bufferWriter.WrittenSpan.CopyTo(rented);
+
+        // Block the worker thread when the channel is full, applying backpressure.
+        // Pass the cancellation token so that a cancelled consumer unblocks this call
+        // rather than causing an infinite wait when the bounded channel is saturated.
+        _channelWriter.WriteAsync(new PooledEventBuffer(rented, length), _cancellationToken)
+            .AsTask().GetAwaiter().GetResult();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteStructBegin() => _jsonWriter.WriteStartObject();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteStructEnd() => _jsonWriter.WriteEndObject();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WritePropertyBegin(PropertyMetadata metadata) => _jsonWriter.WritePropertyName(metadata.Name);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WritePropertyEnd() { }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteArrayBegin() => _jsonWriter.WriteStartArray();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteArrayEnd() => _jsonWriter.WriteEndArray();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteAnsiString(string value) => _jsonWriter.WriteStringValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteUnicodeString(string value) => _jsonWriter.WriteStringValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteInt8(sbyte value) => _jsonWriter.WriteNumberValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteUInt8(byte value) => _jsonWriter.WriteNumberValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteInt16(short value) => _jsonWriter.WriteNumberValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteUInt16(ushort value) => _jsonWriter.WriteNumberValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteInt32(int value) => _jsonWriter.WriteNumberValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteUInt32(uint value) => _jsonWriter.WriteNumberValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteInt64(long value) => _jsonWriter.WriteNumberValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteUInt64(ulong value) => _jsonWriter.WriteNumberValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteFloat(float value) => _jsonWriter.WriteNumberValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteDouble(double value) => _jsonWriter.WriteNumberValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteBoolean(bool value) => _jsonWriter.WriteBooleanValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteBinary(byte[] value) => _jsonWriter.WriteBase64StringValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteGuid(Guid value) => _jsonWriter.WriteStringValue(value.ToString("D"));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WritePointer(ulong value) => _jsonWriter.WriteNumberValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteFileTime(DateTime value) => _jsonWriter.WriteStringValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteSystemTime(DateTime value) => _jsonWriter.WriteStringValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteSid(string value) => _jsonWriter.WriteStringValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteUnicodeChar(char value) => _jsonWriter.WriteNumberValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteAnsiChar(char value) => _jsonWriter.WriteNumberValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteHexDump(byte[] value) => _jsonWriter.WriteBase64StringValue(value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteWbemSid(string value) => _jsonWriter.WriteStringValue(value);
+}

--- a/src/EtwJsonChannelWriter.cs
+++ b/src/EtwJsonChannelWriter.cs
@@ -116,7 +116,6 @@ internal sealed class EtwJsonChannelWriter : IEtwWriter
         _jsonWriter.WriteStartObject();
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteEventEnd()
     {
         _jsonWriter.WriteEndObject();
@@ -129,11 +128,21 @@ internal sealed class EtwJsonChannelWriter : IEtwWriter
         byte[] rented = ArrayPool<byte>.Shared.Rent(length);
         _bufferWriter.WrittenSpan.CopyTo(rented);
 
-        // Block the worker thread when the channel is full, applying backpressure.
-        // Pass the cancellation token so that a cancelled consumer unblocks this call
-        // rather than causing an infinite wait when the bounded channel is saturated.
-        _channelWriter.WriteAsync(new PooledEventBuffer(rented, length), _cancellationToken)
-            .AsTask().GetAwaiter().GetResult();
+        try
+        {
+            // Block the worker thread when the channel is full, applying backpressure.
+            // The cancellation token unblocks this wait when the consumer disposes or
+            // cancels so the worker is never permanently stuck on a saturated channel.
+            _channelWriter.WriteAsync(new PooledEventBuffer(rented, length), _cancellationToken)
+                .AsTask().GetAwaiter().GetResult();
+        }
+        catch
+        {
+            // Return the buffer to the pool before propagating so it is not leaked
+            // when the channel write is cancelled or the channel is completed.
+            ArrayPool<byte>.Shared.Return(rented);
+            throw;
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/EtwUtil.cs
+++ b/src/EtwUtil.cs
@@ -225,21 +225,26 @@ public static class EtwUtil
                 FullMode = BoundedChannelFullMode.Wait
             });
 
-        EtwJsonChannelWriter channelWriter = new(channel.Writer, cancellationToken);
+        // Linked source so that both the caller's token AND enumerator disposal (break /
+        // early exit without explicit cancellation) reliably unblock the worker thread.
+        CancellationTokenSource linkedCts =
+            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        EtwJsonChannelWriter channelWriter = new(channel.Writer, linkedCts.Token);
         Deserializer<EtwJsonChannelWriter> deserializer = new(
             channelWriter,
             opts.CustomProviderManifest,
             opts.WppDecodingContext
         );
 
-        Thread workerThread = new(() => RunWorker(list, opts, deserializer, channel.Writer, cancellationToken))
+        Thread workerThread = new(() => RunWorker(list, opts, deserializer, channel.Writer, linkedCts.Token))
         {
             IsBackground = true,
             Name = "EtwUtil.EnumerateEventsAsync worker"
         };
         workerThread.Start();
 
-        return StreamEventsAsync(channel.Reader, workerThread, cancellationToken);
+        return StreamEventsAsync(channel.Reader, workerThread, linkedCts, cancellationToken);
     }
 
     private static void RunWorker(
@@ -252,6 +257,7 @@ public static class EtwUtil
         int count = list.Count;
         EVENT_TRACE_LOGFILEW[] fileSessions = new EVENT_TRACE_LOGFILEW[count];
         ulong[] handles = new ulong[count];
+        int[] openTraceErrors = new int[count];
 
         try
         {
@@ -273,6 +279,8 @@ public static class EtwUtil
                     }
 
                     handles[i] = Etw.OpenTrace(ref fileSessions[i]);
+                    // Capture immediately: any subsequent Win32 call would overwrite the TLS slot.
+                    openTraceErrors[i] = Marshal.GetLastWin32Error();
                 }
             }
 
@@ -282,7 +290,7 @@ public static class EtwUtil
                 {
                     if (handles[i] == (ulong)~0)
                     {
-                        WIN32_ERROR error = (WIN32_ERROR)Marshal.GetLastWin32Error();
+                        WIN32_ERROR error = (WIN32_ERROR)openTraceErrors[i];
                         EtwOpenTraceException ex = new(error, list[i]);
                         opts.ReportError?.Invoke("ERROR: " + ex.Message);
                         writer.TryComplete(ex);
@@ -322,6 +330,7 @@ public static class EtwUtil
     private static async IAsyncEnumerable<ReadOnlyMemory<byte>> StreamEventsAsync(
         ChannelReader<PooledEventBuffer> reader,
         Thread workerThread,
+        CancellationTokenSource linkedCts,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         PooledEventBuffer? previous = null;
@@ -348,8 +357,14 @@ public static class EtwUtil
                 ArrayPool<byte>.Shared.Return(previous.Value.Rented);
             }
 
+            // Signal the worker to stop if it is still blocked waiting on a full channel
+            // (e.g., consumer broke out early without cancelling the caller's token).
+            // This ensures ETW handles are always released promptly.
+            linkedCts.Cancel();
+
             // Wait for the worker thread to finish so handles are closed before we return.
             workerThread.Join(millisecondsTimeout: 5000);
+            linkedCts.Dispose();
         }
     }
 }

--- a/src/EtwUtil.cs
+++ b/src/EtwUtil.cs
@@ -215,36 +215,11 @@ public static class EtwUtil
         EtwJsonConverterOptions opts = new();
         options?.Invoke(opts);
 
-        // Bounded channel: limits how far ahead the producer can run relative to the consumer.
-        const int channelCapacity = 256;
-        Channel<PooledEventBuffer> channel = Channel.CreateBounded<PooledEventBuffer>(
-            new BoundedChannelOptions(channelCapacity)
-            {
-                SingleWriter = true,
-                SingleReader = true,
-                FullMode = BoundedChannelFullMode.Wait
-            });
-
-        // Linked source so that both the caller's token AND enumerator disposal (break /
-        // early exit without explicit cancellation) reliably unblock the worker thread.
-        CancellationTokenSource linkedCts =
-            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-        EtwJsonChannelWriter channelWriter = new(channel.Writer, linkedCts.Token);
-        Deserializer<EtwJsonChannelWriter> deserializer = new(
-            channelWriter,
-            opts.CustomProviderManifest,
-            opts.WppDecodingContext
-        );
-
-        Thread workerThread = new(() => RunWorker(list, opts, deserializer, channel.Writer, linkedCts.Token))
-        {
-            IsBackground = true,
-            Name = "EtwUtil.EnumerateEventsAsync worker"
-        };
-        workerThread.Start();
-
-        return StreamEventsAsync(channel.Reader, workerThread, linkedCts, cancellationToken);
+        // Defer all resource creation (channel, linked CTS, deserializer, worker thread) into
+        // the async iterator so that nothing is allocated or started until MoveNextAsync is
+        // first called.  If the returned IAsyncEnumerable is never iterated, no resources are
+        // consumed and no worker thread is started.
+        return StreamEventsAsync(list, opts, cancellationToken);
     }
 
     private static void RunWorker(
@@ -328,16 +303,48 @@ public static class EtwUtil
     }
 
     private static async IAsyncEnumerable<ReadOnlyMemory<byte>> StreamEventsAsync(
-        ChannelReader<PooledEventBuffer> reader,
-        Thread workerThread,
-        CancellationTokenSource linkedCts,
+        List<string> list,
+        EtwJsonConverterOptions opts,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        // All resources are created here — inside the iterator body — so they are only
+        // allocated when MoveNextAsync is first called.  If the IAsyncEnumerable is never
+        // iterated the worker thread is never started and no ETW handles are opened.
+
+        const int channelCapacity = 256;
+        Channel<PooledEventBuffer> channel = Channel.CreateBounded<PooledEventBuffer>(
+            new BoundedChannelOptions(channelCapacity)
+            {
+                SingleWriter = true,
+                SingleReader = true,
+                FullMode = BoundedChannelFullMode.Wait
+            });
+
+        // Linked source: cancelled by either the caller's token or enumerator disposal
+        // (break / early exit without explicit cancellation) so the worker is never
+        // permanently blocked on a saturated channel.
+        CancellationTokenSource linkedCts =
+            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        EtwJsonChannelWriter channelWriter = new(channel.Writer, linkedCts.Token);
+        Deserializer<EtwJsonChannelWriter> deserializer = new(
+            channelWriter,
+            opts.CustomProviderManifest,
+            opts.WppDecodingContext
+        );
+
+        Thread workerThread = new(() => RunWorker(list, opts, deserializer, channel.Writer, linkedCts.Token))
+        {
+            IsBackground = true,
+            Name = "EtwUtil.EnumerateEventsAsync worker"
+        };
+        workerThread.Start();
+
         PooledEventBuffer? previous = null;
 
         try
         {
-            await foreach (PooledEventBuffer item in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            await foreach (PooledEventBuffer item in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
             {
                 // Return previous rental before yielding the next item.
                 if (previous.HasValue)

--- a/src/EtwUtil.cs
+++ b/src/EtwUtil.cs
@@ -1,11 +1,15 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Threading.Channels;
 
 using Windows.Win32.Foundation;
 
 using Nefarius.Utilities.ETW.Deserializer;
 using Nefarius.Utilities.ETW.Deserializer.WPP;
+using Nefarius.Utilities.ETW.Exceptions;
 
 namespace Nefarius.Utilities.ETW;
 
@@ -156,5 +160,196 @@ public static class EtwUtil
 
         jsonWriter.Flush();
         return true;
+    }
+
+    /// <summary>
+    ///     Converts one or more .ETL files to a stream of UTF-8 JSON objects, yielding each decoded event
+    ///     as a <see cref="ReadOnlyMemory{T}">ReadOnlyMemory&lt;byte&gt;</see> as it is produced.
+    /// </summary>
+    /// <param name="inputFiles">One or more input files.</param>
+    /// <param name="options">Options to further tweak the parsing operation.</param>
+    /// <param name="cancellationToken">Token that, when cancelled, stops trace processing and completes the enumeration.</param>
+    /// <returns>
+    ///     An <see cref="IAsyncEnumerable{T}" /> of raw UTF-8 JSON buffers, one per event. Each buffer contains a
+    ///     self-contained JSON object — <c>{"Event":{"Timestamp":…,"Properties":[{…}]}}</c> — with no outer
+    ///     array wrapper. The caller may concatenate or wrap the items as needed.
+    /// </returns>
+    /// <remarks>
+    ///     <para>
+    ///         Each <see cref="ReadOnlyMemory{T}">ReadOnlyMemory&lt;byte&gt;</see> is backed by a buffer rented from
+    ///         <see cref="ArrayPool{T}.Shared" />. The buffer is valid only until the next iteration step; the library
+    ///         returns it to the pool when <c>MoveNextAsync</c> is called (i.e. at the start of the next
+    ///         <see langword="await foreach" /> loop body). Do not retain references to the memory across iterations.
+    ///     </para>
+    ///     <para>
+    ///         Trace processing runs on a dedicated background thread so the thread-pool is not blocked by the
+    ///         long-running native <c>ProcessTrace</c> call. A bounded channel with a fixed capacity couples the
+    ///         producer to the consumer, applying natural backpressure when the consumer is slower than the trace.
+    ///     </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="inputFiles" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">
+    ///     One or more entries in <paramref name="inputFiles" /> are <see langword="null" />, empty, or consist only of
+    ///     whitespace.
+    /// </exception>
+    /// <exception cref="EtwOpenTraceException">
+    ///     One of the input files could not be opened by the ETW API.
+    /// </exception>
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public static IAsyncEnumerable<ReadOnlyMemory<byte>> EnumerateEventsAsync(
+        IEnumerable<string> inputFiles,
+        Action<EtwJsonConverterOptions>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(inputFiles);
+
+        List<string> list = inputFiles.ToList();
+        for (int i = 0; i < list.Count; i++)
+        {
+            if (string.IsNullOrWhiteSpace(list[i]))
+            {
+                throw new ArgumentException($"Entry at index {i} is null, empty, or whitespace.", nameof(inputFiles));
+            }
+        }
+
+        EtwJsonConverterOptions opts = new();
+        options?.Invoke(opts);
+
+        // Bounded channel: limits how far ahead the producer can run relative to the consumer.
+        const int channelCapacity = 256;
+        Channel<PooledEventBuffer> channel = Channel.CreateBounded<PooledEventBuffer>(
+            new BoundedChannelOptions(channelCapacity)
+            {
+                SingleWriter = true,
+                SingleReader = true,
+                FullMode = BoundedChannelFullMode.Wait
+            });
+
+        EtwJsonChannelWriter channelWriter = new(channel.Writer, cancellationToken);
+        Deserializer<EtwJsonChannelWriter> deserializer = new(
+            channelWriter,
+            opts.CustomProviderManifest,
+            opts.WppDecodingContext
+        );
+
+        Thread workerThread = new(() => RunWorker(list, opts, deserializer, channel.Writer, cancellationToken))
+        {
+            IsBackground = true,
+            Name = "EtwUtil.EnumerateEventsAsync worker"
+        };
+        workerThread.Start();
+
+        return StreamEventsAsync(channel.Reader, workerThread, cancellationToken);
+    }
+
+    private static void RunWorker(
+        List<string> list,
+        EtwJsonConverterOptions opts,
+        Deserializer<EtwJsonChannelWriter> deserializer,
+        ChannelWriter<PooledEventBuffer> writer,
+        CancellationToken cancellationToken)
+    {
+        int count = list.Count;
+        EVENT_TRACE_LOGFILEW[] fileSessions = new EVENT_TRACE_LOGFILEW[count];
+        ulong[] handles = new ulong[count];
+
+        try
+        {
+            for (int i = 0; i < count; ++i)
+            {
+                unsafe
+                {
+                    fileSessions[i] = new EVENT_TRACE_LOGFILEW
+                    {
+                        LogFileName = list[i],
+                        EventRecordCallback = deserializer.Deserialize,
+                        BufferCallback = _ => !cancellationToken.IsCancellationRequested,
+                        LogFileMode = PInvoke.PROCESS_TRACE_MODE_EVENT_RECORD
+                    };
+
+                    if (opts.PreserveRawTimestamps)
+                    {
+                        fileSessions[i].LogFileMode |= PInvoke.PROCESS_TRACE_MODE_RAW_TIMESTAMP;
+                    }
+
+                    handles[i] = Etw.OpenTrace(ref fileSessions[i]);
+                }
+            }
+
+            for (int i = 0; i < count; ++i)
+            {
+                unchecked
+                {
+                    if (handles[i] == (ulong)~0)
+                    {
+                        WIN32_ERROR error = (WIN32_ERROR)Marshal.GetLastWin32Error();
+                        EtwOpenTraceException ex = new(error, list[i]);
+                        opts.ReportError?.Invoke("ERROR: " + ex.Message);
+                        writer.TryComplete(ex);
+                        return;
+                    }
+                }
+            }
+
+            Etw.ProcessTrace(handles, (uint)handles.Length, IntPtr.Zero, IntPtr.Zero);
+            GC.KeepAlive(fileSessions);
+        }
+        catch (Exception ex)
+        {
+            writer.TryComplete(ex);
+            return;
+        }
+        finally
+        {
+            for (int i = 0; i < count; ++i)
+            {
+                if (handles[i] != 0)
+                {
+                    unchecked
+                    {
+                        if (handles[i] != (ulong)~0)
+                        {
+                            Etw.CloseTrace(handles[i]);
+                        }
+                    }
+                }
+            }
+        }
+
+        writer.TryComplete();
+    }
+
+    private static async IAsyncEnumerable<ReadOnlyMemory<byte>> StreamEventsAsync(
+        ChannelReader<PooledEventBuffer> reader,
+        Thread workerThread,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        PooledEventBuffer? previous = null;
+
+        try
+        {
+            await foreach (PooledEventBuffer item in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                // Return previous rental before yielding the next item.
+                if (previous.HasValue)
+                {
+                    ArrayPool<byte>.Shared.Return(previous.Value.Rented);
+                }
+
+                previous = item;
+                yield return item.Memory;
+            }
+        }
+        finally
+        {
+            // Return the last rental, if any.
+            if (previous.HasValue)
+            {
+                ArrayPool<byte>.Shared.Return(previous.Value.Rented);
+            }
+
+            // Wait for the worker thread to finish so handles are closed before we return.
+            workerThread.Join(millisecondsTimeout: 5000);
+        }
     }
 }

--- a/src/Exceptions/EtwOpenTraceException.cs
+++ b/src/Exceptions/EtwOpenTraceException.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel;
+
+using Windows.Win32.Foundation;
+
+namespace Nefarius.Utilities.ETW.Exceptions;
+
+/// <inheritdoc />
+public sealed class EtwOpenTraceException : Win32Exception
+{
+    internal EtwOpenTraceException(WIN32_ERROR error, string filePath)
+        : base((int)error, BuildMessage(error, filePath)) { }
+
+    private static string BuildMessage(WIN32_ERROR error, string filePath) =>
+        error switch
+        {
+            WIN32_ERROR.ERROR_INVALID_PARAMETER => $"For file: {filePath} Windows returned 0x57 -- The Logfile parameter is NULL.",
+            WIN32_ERROR.ERROR_BAD_PATHNAME => $"For file: {filePath} Windows returned 0xA1 -- The specified path is invalid.",
+            WIN32_ERROR.ERROR_ACCESS_DENIED => $"For file: {filePath} Windows returned 0x5 -- Access is denied.",
+            _ => $"For file: {filePath} Windows returned an unknown error."
+        };
+}

--- a/tests/UnitTestStreaming.cs
+++ b/tests/UnitTestStreaming.cs
@@ -103,6 +103,13 @@ public class StreamingTests
         const string etwFilePath = @".\traces\BthPS3_0.etl";
         const int cancelAfter = 10;
 
+        // Provide the full decoding context so WPP events are decoded and the trace
+        // yields well more than cancelAfter items before the cancellation is triggered.
+        DecodingContext decodingContext = new(PdbFileDecodingContextType.CreateFrom(
+            @".\symbols\BthPS3.pdb",
+            @".\symbols\BthPS3PSM.pdb"
+        ));
+
         using CancellationTokenSource cts = new();
 
         int received = 0;
@@ -112,7 +119,8 @@ public class StreamingTests
         {
             await foreach (ReadOnlyMemory<byte> _ in EtwUtil.EnumerateEventsAsync(
                                [etwFilePath],
-                               cancellationToken: cts.Token))
+                               opts => opts.WppDecodingContext = decodingContext,
+                               cts.Token))
             {
                 received++;
                 if (received >= cancelAfter)

--- a/tests/UnitTestStreaming.cs
+++ b/tests/UnitTestStreaming.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+
+using Nefarius.Utilities.ETW.Deserializer.WPP;
+
+namespace Nefarius.Utilities.ETW.Tests;
+
+/// <summary>
+///     Tests for <see cref="EtwUtil.EnumerateEventsAsync" />.
+/// </summary>
+[Category("Streaming")]
+public class StreamingTests
+{
+    // -----------------------------------------------------------------------
+    // Smoke test: events are streamed and structurally correct
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Category("EndToEnd")]
+    public async Task StreamingEnumerationYieldsEventsTest()
+    {
+        const string etwFilePath = @".\traces\BthPS3_0.etl";
+
+        DecodingContext decodingContext = new(PdbFileDecodingContextType.CreateFrom(
+            @".\symbols\BthPS3.pdb",
+            @".\symbols\BthPS3PSM.pdb"
+        ));
+
+        int eventCount = 0;
+        bool hasDecodedWppEvent = false;
+
+        await foreach (ReadOnlyMemory<byte> eventBytes in EtwUtil.EnumerateEventsAsync(
+                           [etwFilePath],
+                           opts => opts.WppDecodingContext = decodingContext))
+        {
+            eventCount++;
+
+            using JsonDocument doc = JsonDocument.Parse(eventBytes);
+            JsonElement root = doc.RootElement;
+            JsonElement evt = root.GetProperty("Event");
+
+            string? name = evt.GetProperty("Name").GetString();
+            if (name == "WPP")
+            {
+                string? fs = evt.GetProperty("Properties")[0].GetProperty("FormattedString").GetString();
+                if (fs is not null && !fs.StartsWith("GUID="))
+                {
+                    hasDecodedWppEvent = true;
+                }
+            }
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(eventCount, Is.GreaterThan(0),
+                "Streaming enumeration must yield at least one event.");
+
+            Assert.That(hasDecodedWppEvent, Is.True,
+                "At least one WPP event must have a successfully decoded FormattedString (not the fallback 'GUID=...' message).");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Smoke test: event count matches the synchronous ConvertToJson output
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Category("EndToEnd")]
+    public async Task StreamingEventCountMatchesSynchronousTest()
+    {
+        const string etwFilePath = @".\traces\BthPS3_0.etl";
+
+        DecodingContext decodingContext = new(PdbFileDecodingContextType.CreateFrom(
+            @".\symbols\BthPS3.pdb",
+            @".\symbols\BthPS3PSM.pdb"
+        ));
+
+        // Count events via the synchronous JSON path.
+        string fullJson = Shared.BthPs3EtlTraceDecodeToString();
+        using JsonDocument syncDoc = JsonDocument.Parse(fullJson);
+        int syncCount = syncDoc.RootElement.GetProperty("Events").GetArrayLength();
+
+        // Count events via the streaming path.
+        int streamCount = 0;
+        await foreach (ReadOnlyMemory<byte> _ in EtwUtil.EnumerateEventsAsync(
+                           [etwFilePath],
+                           opts => opts.WppDecodingContext = decodingContext))
+        {
+            streamCount++;
+        }
+
+        Assert.That(streamCount, Is.EqualTo(syncCount),
+            "Streaming path must yield the same number of events as the synchronous path.");
+    }
+
+    // -----------------------------------------------------------------------
+    // Cancellation: enumerator terminates cleanly when cancelled mid-stream
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Category("EndToEnd")]
+    public async Task CancellationStopsEnumerationTest()
+    {
+        const string etwFilePath = @".\traces\BthPS3_0.etl";
+        const int cancelAfter = 10;
+
+        using CancellationTokenSource cts = new();
+
+        int received = 0;
+        bool cancelled = false;
+
+        try
+        {
+            await foreach (ReadOnlyMemory<byte> _ in EtwUtil.EnumerateEventsAsync(
+                               [etwFilePath],
+                               cancellationToken: cts.Token))
+            {
+                received++;
+                if (received >= cancelAfter)
+                {
+                    cts.Cancel();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            cancelled = true;
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(received, Is.GreaterThanOrEqualTo(cancelAfter),
+                "Must have received at least the requested number of events before cancelling.");
+
+            Assert.That(cancelled, Is.True,
+                "OperationCanceledException must be propagated to the caller on cancellation.");
+        }
+    }
+}

--- a/tests/UnitTestStreaming.cs
+++ b/tests/UnitTestStreaming.cs
@@ -143,4 +143,40 @@ public class StreamingTests
                 "OperationCanceledException must be propagated to the caller on cancellation.");
         }
     }
+
+    // -----------------------------------------------------------------------
+    // Disposal path: break without CancellationToken — worker must exit cleanly
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Category("EndToEnd")]
+    public async Task EarlyBreakWithoutCancellationDisposesCleanlyTest()
+    {
+        const string etwFilePath = @".\traces\BthPS3_0.etl";
+        const int breakAfter = 10;
+
+        DecodingContext decodingContext = new(PdbFileDecodingContextType.CreateFrom(
+            @".\symbols\BthPS3.pdb",
+            @".\symbols\BthPS3PSM.pdb"
+        ));
+
+        int received = 0;
+
+        // No CancellationTokenSource — exercises the linked-CTS disposal path that
+        // unblocks the producer when the consumer breaks early without cancelling.
+        await foreach (ReadOnlyMemory<byte> _ in EtwUtil.EnumerateEventsAsync(
+                           [etwFilePath],
+                           opts => opts.WppDecodingContext = decodingContext))
+        {
+            received++;
+            if (received >= breakAfter)
+            {
+                break;
+            }
+        }
+
+        // No OperationCanceledException expected; loop must have completed normally.
+        Assert.That(received, Is.EqualTo(breakAfter),
+            "Consumer must receive exactly the requested number of events before breaking.");
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async streaming API to enumerate ETW events as incremental UTF‑8 JSON payloads
  * Writer that publishes pooled JSON event buffers for efficient consumption

* **Improvements**
  * More detailed per-file error messages when opening traces
  * Robust cancellation, disposal and resource cleanup during streaming

* **Tests**
  * End-to-end tests for streaming, consistency, cancellation and early-disposal scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/Nefarius.Utilities.ETW/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->