### PR TITLE
Added Trace Control Provider GUID extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ contributors.*
 - Replaced P/Invoke code with [source generators](https://github.com/microsoft/CsWin32)
 - Changed namespace to `Nefarius.Utilities.ETW` to avoid conflicts with the origin library
 - Added support for [WPP Software Tracing](https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/wpp-software-tracing) decoding
-  - Supports `.PDB` files as a decoding source
+  - Supports `.PDB` files as a decoding source — WPP provider GUIDs (ETW trace control GUIDs) are automatically extracted from `TMC:` annotations in the PDB symbol stream so no manual GUID lookup is required
   - Supports `.TMF` files as a decoding source
   - Full support for all [WPP extended format specification strings](https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/what-are-the-wpp-extended-format-specification-strings-)
     (`%!FUNC!`, `%!LEVEL!`, `%!FLAGS!`, `%!IPADDR!`, `%!TIMESTAMP!`, `%!delta!`, `%!due!`, `%!GUID!`,
@@ -133,15 +133,26 @@ The `tools/Nefarius.Utilities.ETW.RealtimeCli` project builds a self-contained c
 ### Usage
 
 ```text
-realtimewpp realtime <provider-guid> [<provider-guid> ...]
+realtimewpp realtime [<provider-guid> ...]
     [--keywords           <hex|dec>]   # match-any mask, default 0xFFFFFFFFFFFFFFFF
     [--match-all-keywords <hex|dec>]   # match-all mask, default 0
     [--level <Critical|Error|Warning|Information|Verbose>]  # default Verbose
     [--session-name <name>]            # default NefariusEtwCli-<pid>
-    [--symbols <path>] ...             # repeatable; literal file, directory, or glob
+    [--symbols <path>] ...             # repeatable; PDB file, directory, or glob
     [--buffer-size-kb <n>]             # ETW buffer size, default 64
     [--flush-seconds  <n>]             # flush interval, default 1
 ```
+
+`provider-guid` is **optional**. When omitted, the tool reads the `WPP_DEFINE_CONTROL_GUID` declarations embedded in the PDB files passed to `--symbols` and uses those as the provider list. Explicit GUIDs always take precedence; PDB-derived GUIDs are not added on top of explicit ones.
+
+> **Note:** Auto-derivation requires **PDB files**. TMF files do not contain the WPP control GUID (they only hold per-call-site message format data). If `--symbols` points to a directory or glob that contains only TMF files, you must also supply `provider-guid` explicitly.
+
+```text
+realtimewpp inspect-pdb <path> [<path> ...]
+    [--format <plain|ndjson>]          # output format, default plain
+```
+
+Parses one or more PDB files and lists every WPP provider GUID (`WPP_DEFINE_CONTROL_GUID`) found, along with the control name and declared `WPP_DEFINE_BIT` flag names. No ETW session is started. Accepts the same path forms as `--symbols` (PDB files, directories, glob patterns). TMF files are silently ignored.
 
 ### Examples
 
@@ -150,6 +161,13 @@ Capture all events from a provider and pretty-print them with `jq`:
 ```bash
 # Replace the GUID below with the actual provider GUID you want to trace.
 realtimewpp realtime {12345678-1234-1234-1234-1234567890AB} | jq .
+```
+
+Auto-derive the provider GUID from a PDB and stream all events:
+
+```bash
+# The control GUID is extracted from WPP_DEFINE_CONTROL_GUID in the PDB.
+realtimewpp realtime --symbols C:\Symbols\MyDriver.pdb | jq .
 ```
 
 Capture only errors and warnings, with WPP symbol files loaded from a directory:
@@ -161,12 +179,32 @@ realtimewpp realtime {12345678-1234-1234-1234-1234567890AB} \
     --symbols C:\Symbols\TMFs\
 ```
 
-Glob expansion — load every PDB from an entire symbol tree:
+Glob expansion — load every PDB from an entire symbol tree, auto-derive all providers:
 
 ```bash
-realtimewpp realtime {12345678-1234-1234-1234-1234567890AB} \
+realtimewpp realtime \
     --keywords 0xFFFFFFFF --level Verbose \
     --symbols "C:\Symbols\**\*.pdb"
+```
+
+List provider GUIDs embedded in a PDB (plain, human-readable — includes control name and bit flags):
+
+```text
+realtimewpp inspect-pdb C:\Symbols\MyDriver.pdb
+
+{37DCD579-E844-4C80-9C8B-A10850B6FAC6}  BthPS3TraceGuid                 (BthPS3.pdb, 9 bit flags)
+    MYDRIVER_ALL_INFO
+    TRACE_DRIVER
+    TRACE_DEVICE
+    TRACE_QUEUE
+    ...
+```
+
+List provider GUIDs as NDJSON for use in a script:
+
+```bash
+realtimewpp inspect-pdb C:\Symbols\MyDriver.pdb --format ndjson | jq .
+# { "guid": "{37DCD579-...}", "name": "BthPS3TraceGuid", "bitFlags": ["MYDRIVER_ALL_INFO", ...], "source": "BthPS3.pdb" }
 ```
 
 ### NDJSON contract
@@ -179,12 +217,12 @@ Each line written to `stdout` is a self-contained JSON object. Status and error 
 {"EventName":"ProcessStop","ProcessId":1234, ...}
 
 // stderr — human-readable status (never mixed into stdout)
-[*] Session 'NefariusEtwCli-9876' started. Provider {12345678-...} | level=Verbose | keywords=0xFFFFFFFF
+[*] Session 'NefariusEtwCli-9876' started. Providers (auto-derived from symbols): {37DCD579-...} | level=Verbose | keywords=0xFFFFFFFF
 [*] Streaming events... (Ctrl+C to stop)
 [*] Done.
 
 # Example pipeline
-realtimewpp realtime {12345678-1234-1234-1234-1234567890AB} | jq .
+realtimewpp realtime --symbols C:\Symbols\MyDriver.pdb | jq .
 ```
 
 ## Known limitations

--- a/src/Deserializer/WPP/DecodingContext.cs
+++ b/src/Deserializer/WPP/DecodingContext.cs
@@ -15,6 +15,8 @@ public sealed class DecodingContext
 
     private readonly ReadOnlyDictionary<TraceMessageFormatLookupKey, TraceMessageFormat> _lookup;
 
+    private readonly IReadOnlyCollection<Guid> _providerGuids;
+
     /// <summary>
     ///     New decoding context instance.
     /// </summary>
@@ -29,7 +31,23 @@ public sealed class DecodingContext
             .Distinct()
             .ToDictionary(key => new TraceMessageFormatLookupKey(key.MessageGuid, key.Id), value => value)
             .AsReadOnly();
+
+        // Aggregate the real WPP control GUIDs across all underlying sources.
+        // TMF-only sources return an empty enumerable from ProviderGuids so they are
+        // silently skipped; only PdbFileDecodingContextType contributes entries.
+        _providerGuids = _decodingTypes
+            .SelectMany(t => t.ProviderGuids)
+            .Distinct()
+            .ToArray();
     }
+
+    /// <summary>
+    ///     The deduplicated union of all WPP trace control GUIDs (= ETW provider GUIDs) across every
+    ///     underlying <see cref="DecodingContextType" />.  Each GUID corresponds to one
+    ///     <c>WPP_DEFINE_CONTROL_GUID</c> declaration found in the loaded PDB files.
+    ///     The collection is empty when the context was built from TMF files only.
+    /// </summary>
+    public IReadOnlyCollection<Guid> ProviderGuids => _providerGuids;
 
     internal TraceMessageFormat? GetTraceMessageFormatFor(Guid? messageGuid, int id)
     {

--- a/src/Deserializer/WPP/DecodingContextType.cs
+++ b/src/Deserializer/WPP/DecodingContextType.cs
@@ -13,4 +13,13 @@ public abstract class DecodingContextType
     ///     Collection of extracted <see cref="TraceMessageFormat" />s of this <see cref="DecodingContextType" />.
     /// </summary>
     public IEnumerable<TraceMessageFormat> TraceMessageFormats { get; protected set; } = null!;
+
+    /// <summary>
+    ///     The distinct set of WPP trace control GUIDs (= ETW provider GUIDs) available from this
+    ///     decoding source.  Subclasses that carry the provider GUID — currently only
+    ///     <see cref="PdbFileDecodingContextType" /> via its <c>TMC:</c> annotations — override this
+    ///     property.  TMF-only sources return an empty collection because <c>.tmf</c> files only
+    ///     contain per-call-site message hash GUIDs, not the WPP control GUID.
+    /// </summary>
+    public virtual IEnumerable<Guid> ProviderGuids => [];
 }

--- a/src/Deserializer/WPP/PdbFileDecodingContextType.cs
+++ b/src/Deserializer/WPP/PdbFileDecodingContextType.cs
@@ -1,4 +1,7 @@
-﻿using Kaitai;
+﻿using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+
+using Kaitai;
 
 using Nefarius.Shared.PdbUtils.Extensions;
 using Nefarius.Utilities.ETW.Deserializer.WPP.TMF;
@@ -8,6 +11,8 @@ namespace Nefarius.Utilities.ETW.Deserializer.WPP;
 /// <summary>
 ///     A <see cref="DecodingContextType" /> parsing one or more given <c>.pdb</c> files.
 /// </summary>
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
 public sealed class PdbFileDecodingContextType()
     : DecodingContextType
 {
@@ -37,33 +42,93 @@ public sealed class PdbFileDecodingContextType()
     }
 
     /// <summary>
+    ///     The WPP trace control blocks discovered in this PDB — one entry per
+    ///     <c>WPP_DEFINE_CONTROL_GUID</c> declaration found in the symbol stream.
+    ///     Each entry contains the provider GUID, its friendly name, and the declared
+    ///     <c>WPP_DEFINE_BIT</c> flag names.
+    /// </summary>
+    public IReadOnlyCollection<WppTraceControl> WppTraceControls { get; private set; } =
+        new ReadOnlyCollection<WppTraceControl>([]);
+
+    /// <inheritdoc />
+    /// <remarks>
+    ///     For PDB sources the provider GUIDs are the WPP trace control GUIDs extracted from
+    ///     <c>TMC:</c> <c>S_ANNOTATION</c> records in the symbol stream — one per
+    ///     <c>WPP_DEFINE_CONTROL_GUID</c> declaration.
+    /// </remarks>
+    public override IEnumerable<Guid> ProviderGuids =>
+        WppTraceControls.Select(c => c.ControlGuid);
+
+    /// <summary>
     ///     Initializes the decoding context from a KaitaiStream.
     /// </summary>
-    /// <param name="kaitaiStream">Kaitai stream containing PDB data.</param>
     private void InitializeFromStream(KaitaiStream kaitaiStream)
     {
         MsPdb pdb = new(kaitaiStream);
         string? originalName = pdb.GetOriginalPdbName();
 
-        IEnumerable<SymProc32AnnotationPair> annotations = pdb
-            .DbiStream.ModulesList.Items
+        // Materialise the full flat symbol list once so we can pass it to both extractors
+        // without iterating the module list twice.
+        List<MsPdb.DbiSymbol> allSymbols = pdb.DbiStream.ModulesList.Items
             .SelectMany(m => m.ModuleData.SymbolsList.Items)
-            .ToList()
-            .ExtractTmfAnnotations();
+            .ToList();
 
         TraceMessageFormats = TmfParser
-            .ExtractTraceMessageFormats(annotations, originalName)
+            .ExtractTraceMessageFormats(allSymbols.ExtractTmfAnnotations(), originalName)
             .Distinct();
+
+        WppTraceControls = allSymbols
+            .ExtractTraceControls()
+            .Select(c => c with { OriginalSymbolFileName = originalName })
+            .DistinctBy(c => c.ControlGuid)
+            .ToList()
+            .AsReadOnly();
     }
 
     /// <summary>
-    ///     Converts a list of paths to <c>*.pdb</c> files into their corresponding <see cref="PdbFileDecodingContextType" />
-    ///     objects.
+    ///     Converts a list of paths to <c>*.pdb</c> files into their corresponding
+    ///     <see cref="PdbFileDecodingContextType" /> objects.
     /// </summary>
     /// <param name="pathList">One or more paths to <c>.pdb</c> files.</param>
     /// <returns>One or more <see cref="PdbFileDecodingContextType" />s.</returns>
     public static IList<DecodingContextType> CreateFrom(params IList<string> pathList)
     {
         return pathList.Select(DecodingContextType (path) => new PdbFileDecodingContextType(path)).ToList();
+    }
+
+    /// <summary>
+    ///     Convenience helper that parses a single <c>.pdb</c> file and returns the distinct set of
+    ///     WPP trace control GUIDs (= ETW provider GUIDs) embedded in it.
+    /// </summary>
+    /// <param name="path">Relative or absolute path to a <c>.pdb</c> file.</param>
+    /// <returns>
+    ///     A distinct, read-only collection of <see cref="Guid" />s — one per
+    ///     <c>WPP_DEFINE_CONTROL_GUID</c> block found in the PDB. The collection is empty if the
+    ///     PDB contains no WPP <c>TMC:</c> annotations.
+    /// </returns>
+    public static IReadOnlyCollection<Guid> EnumerateProviderGuids(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        PdbFileDecodingContextType ctx = new(path);
+        return ctx.WppTraceControls.Select(c => c.ControlGuid).ToArray();
+    }
+
+    /// <summary>
+    ///     Convenience helper that parses a single <c>.pdb</c> file and returns the full
+    ///     <see cref="WppTraceControl" /> records found in it — including the provider GUID,
+    ///     friendly name, and <c>WPP_DEFINE_BIT</c> flag names.
+    /// </summary>
+    /// <param name="path">Relative or absolute path to a <c>.pdb</c> file.</param>
+    /// <returns>
+    ///     A read-only collection of <see cref="WppTraceControl" />s, deduplicated by
+    ///     <see cref="WppTraceControl.ControlGuid" />. Empty if the PDB has no WPP annotations.
+    /// </returns>
+    public static IReadOnlyCollection<WppTraceControl> EnumerateTraceControls(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        PdbFileDecodingContextType ctx = new(path);
+        return ctx.WppTraceControls;
     }
 }

--- a/src/Deserializer/WPP/TMF/DbiSymbolExtensions.cs
+++ b/src/Deserializer/WPP/TMF/DbiSymbolExtensions.cs
@@ -4,6 +4,46 @@ namespace Nefarius.Utilities.ETW.Deserializer.WPP.TMF;
 
 internal static class DbiSymbolExtensions
 {
+    /// <summary>
+    ///     Walks every symbol in the list and yields a <see cref="WppTraceControl" /> for each
+    ///     standalone <c>S_ANNOTATION</c> record whose first string is <c>"TMC:"</c>.  These records
+    ///     are emitted by the WPP pre-processor — one per <c>WPP_DEFINE_CONTROL_GUID</c> declaration —
+    ///     and are NOT paired with a preceding <c>S_GPROC32</c>, unlike the TMF call-site records.
+    /// </summary>
+    public static IEnumerable<WppTraceControl> ExtractTraceControls(
+        this IReadOnlyList<MsPdb.DbiSymbol> symbols)
+    {
+        foreach (MsPdb.DbiSymbol sym in symbols)
+        {
+            if (sym.Data.Body is not MsPdb.SymAnnotation ann)
+            {
+                continue;
+            }
+
+            if (ann.Strings.Count < 3)
+            {
+                continue;
+            }
+
+            if (ann.Strings[0] != "TMC:")
+            {
+                continue;
+            }
+
+            if (!Guid.TryParse(ann.Strings[1], out Guid controlGuid))
+            {
+                continue;
+            }
+
+            yield return new WppTraceControl
+            {
+                ControlGuid = controlGuid,
+                Name = ann.Strings[2],
+                BitFlags = ann.Strings.Skip(3).ToList()
+            };
+        }
+    }
+
     public static IEnumerable<SymProc32AnnotationPair> ExtractTmfAnnotations(
         this IReadOnlyList<MsPdb.DbiSymbol> symbols
     )

--- a/src/Deserializer/WPP/TMF/WppTraceControl.cs
+++ b/src/Deserializer/WPP/TMF/WppTraceControl.cs
@@ -1,0 +1,49 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nefarius.Utilities.ETW.Deserializer.WPP.TMF;
+
+/// <summary>
+///     Describes a single WPP <c>WPP_DEFINE_CONTROL_GUID</c> declaration recovered from a PDB.
+///     The <see cref="ControlGuid" /> is the GUID passed to <c>EnableTraceEx2</c> to enable
+///     the WPP provider on an ETW session.
+/// </summary>
+/// <remarks>
+///     <para>
+///         In the PDB symbol stream WPP places one <c>S_ANNOTATION</c> record per
+///         <c>WPP_DEFINE_CONTROL_GUID</c> declaration. The annotation strings are laid out as:
+///     </para>
+///     <list type="number">
+///         <item><c>"TMC:"</c> — marker that identifies this as a trace control record</item>
+///         <item><c>"&lt;control-guid&gt;"</c> — the WPP control GUID in textual form</item>
+///         <item><c>"&lt;control-name&gt;"</c> — the friendly control GUID name</item>
+///         <item><c>"&lt;flag-bit-N&gt;"</c> — zero or more <c>WPP_DEFINE_BIT</c> flag names</item>
+///     </list>
+/// </remarks>
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+public sealed record WppTraceControl
+{
+    /// <summary>
+    ///     The WPP trace control GUID. This is the GUID that identifies the provider in ETW
+    ///     and that must be passed to <c>EnableTraceEx2</c> to enable the provider on a session.
+    /// </summary>
+    public required Guid ControlGuid { get; init; }
+
+    /// <summary>
+    ///     The friendly name of the control GUID as declared via the first argument of the
+    ///     <c>WPP_DEFINE_CONTROL_GUID</c> macro (for example <c>BthPS3TraceGuid</c>).
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    ///     The ordered list of <c>WPP_DEFINE_BIT</c> flag names declared for this control GUID.
+    ///     Bit index 0 corresponds to ETW keyword <c>0x1</c>, bit index 1 to <c>0x2</c>, and so on.
+    /// </summary>
+    public required IReadOnlyList<string> BitFlags { get; init; } = new ReadOnlyCollection<string>([]);
+
+    /// <summary>
+    ///     The name of the original symbol file the control GUID was extracted from, if known.
+    /// </summary>
+    public string? OriginalSymbolFileName { get; init; }
+}

--- a/tests/UnitTestDecodingContext.cs
+++ b/tests/UnitTestDecodingContext.cs
@@ -13,6 +13,11 @@ public class DecodingContextTests
     private static readonly Guid KnownGuid = Guid.Parse("e4b27b5e-24d0-369f-a4b5-23228e160bd2");
     private const int KnownId = 12;
 
+    // WPP control GUIDs from the TMC: S_ANNOTATION records in the test PDBs.
+    // Verified from tests/symbols/BthPS3.pdb-cvdump.txt and BthPS3PSM.pdb-cvdump.txt.
+    private static readonly Guid BthPS3ControlGuid = Guid.Parse("37dcd579-e844-4c80-9c8b-a10850b6fac6");
+    private static readonly Guid BthPS3PsmControlGuid = Guid.Parse("586aa8b1-53a6-404f-9b3e-14483e514a2c");
+
     // -----------------------------------------------------------------------
     // DecodingContext constructor guards
     // -----------------------------------------------------------------------
@@ -155,5 +160,175 @@ public class DecodingContextTests
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result!.Opcode, Is.EqualTo("Bluetooth_Context_c149"));
+    }
+
+    // -----------------------------------------------------------------------
+    // WppTraceControl / TMC: extraction — PdbFileDecodingContextType
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Category("Parse")]
+    public void PdbFileDecodingContextType_WppTraceControls_ContainsBthPS3ControlGuid()
+    {
+        PdbFileDecodingContextType ctx = new(@".\symbols\BthPS3.pdb");
+
+        Assert.That(ctx.WppTraceControls.Select(c => c.ControlGuid),
+            Does.Contain(BthPS3ControlGuid));
+    }
+
+    [Test]
+    [Category("Parse")]
+    public void PdbFileDecodingContextType_WppTraceControls_HasCorrectName()
+    {
+        PdbFileDecodingContextType ctx = new(@".\symbols\BthPS3.pdb");
+
+        WppTraceControl? ctrl = ctx.WppTraceControls
+            .FirstOrDefault(c => c.ControlGuid == BthPS3ControlGuid);
+
+        Assert.That(ctrl, Is.Not.Null);
+        Assert.That(ctrl!.Name, Is.EqualTo("BthPS3TraceGuid"));
+    }
+
+    [Test]
+    [Category("Parse")]
+    public void PdbFileDecodingContextType_WppTraceControls_HasExpectedBitFlags()
+    {
+        PdbFileDecodingContextType ctx = new(@".\symbols\BthPS3.pdb");
+
+        WppTraceControl? ctrl = ctx.WppTraceControls
+            .FirstOrDefault(c => c.ControlGuid == BthPS3ControlGuid);
+
+        Assert.That(ctrl, Is.Not.Null);
+        // The first four flag names are documented in the cvdump.
+        Assert.That(ctrl!.BitFlags, Does.Contain("MYDRIVER_ALL_INFO"));
+        Assert.That(ctrl.BitFlags, Does.Contain("TRACE_DRIVER"));
+        Assert.That(ctrl.BitFlags, Does.Contain("TRACE_DEVICE"));
+        Assert.That(ctrl.BitFlags, Does.Contain("TRACE_QUEUE"));
+    }
+
+    [Test]
+    [Category("Parse")]
+    public void PdbFileDecodingContextType_ProviderGuids_ContainsBthPS3ControlGuid()
+    {
+        PdbFileDecodingContextType ctx = new(@".\symbols\BthPS3.pdb");
+
+        Assert.That(ctx.ProviderGuids, Does.Contain(BthPS3ControlGuid));
+    }
+
+    // -----------------------------------------------------------------------
+    // EnumerateProviderGuids static helper
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Category("Parse")]
+    public void EnumerateProviderGuids_ReturnsBthPS3ControlGuid()
+    {
+        IReadOnlyCollection<Guid> guids =
+            PdbFileDecodingContextType.EnumerateProviderGuids(@".\symbols\BthPS3.pdb");
+
+        Assert.That(guids, Does.Contain(BthPS3ControlGuid));
+    }
+
+    [Test]
+    [Category("Parse")]
+    public void EnumerateProviderGuids_ReturnsBthPS3PsmControlGuid()
+    {
+        IReadOnlyCollection<Guid> guids =
+            PdbFileDecodingContextType.EnumerateProviderGuids(@".\symbols\BthPS3PSM.pdb");
+
+        Assert.That(guids, Does.Contain(BthPS3PsmControlGuid));
+    }
+
+    [Test]
+    [Category("Parse")]
+    public void EnumerateProviderGuids_ReturnsDistinctGuids()
+    {
+        IReadOnlyCollection<Guid> guids =
+            PdbFileDecodingContextType.EnumerateProviderGuids(@".\symbols\BthPS3.pdb");
+
+        Assert.That(guids.Count, Is.EqualTo(guids.Distinct().Count()));
+    }
+
+    [Test]
+    [Category("Unit")]
+    public void EnumerateProviderGuids_Throws_OnEmptyPath()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            PdbFileDecodingContextType.EnumerateProviderGuids(string.Empty));
+    }
+
+    // -----------------------------------------------------------------------
+    // EnumerateTraceControls static helper
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Category("Parse")]
+    public void EnumerateTraceControls_ReturnsSingleEntryForBthPS3()
+    {
+        IReadOnlyCollection<WppTraceControl> controls =
+            PdbFileDecodingContextType.EnumerateTraceControls(@".\symbols\BthPS3.pdb");
+
+        Assert.That(controls, Has.Count.EqualTo(1));
+        Assert.That(controls.Single().ControlGuid, Is.EqualTo(BthPS3ControlGuid));
+        Assert.That(controls.Single().Name, Is.EqualTo("BthPS3TraceGuid"));
+    }
+
+    [Test]
+    [Category("Unit")]
+    public void EnumerateTraceControls_Throws_OnEmptyPath()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            PdbFileDecodingContextType.EnumerateTraceControls(string.Empty));
+    }
+
+    // -----------------------------------------------------------------------
+    // DecodingContext.ProviderGuids — correct TMC-based values
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Category("Parse")]
+    public void DecodingContext_ProviderGuids_ContainsBothControlGuids()
+    {
+        IList<DecodingContextType> types = PdbFileDecodingContextType
+            .CreateFrom(@".\symbols\BthPS3.pdb", @".\symbols\BthPS3PSM.pdb");
+        DecodingContext context = new(types);
+
+        Assert.That(context.ProviderGuids, Does.Contain(BthPS3ControlGuid));
+        Assert.That(context.ProviderGuids, Does.Contain(BthPS3PsmControlGuid));
+    }
+
+    [Test]
+    [Category("Parse")]
+    public void DecodingContext_ProviderGuids_IsDistinct()
+    {
+        IList<DecodingContextType> types = PdbFileDecodingContextType
+            .CreateFrom(@".\symbols\BthPS3.pdb", @".\symbols\BthPS3PSM.pdb");
+        DecodingContext context = new(types);
+
+        Assert.That(context.ProviderGuids.Count,
+            Is.EqualTo(context.ProviderGuids.Distinct().Count()));
+    }
+
+    [Test]
+    [Category("Parse")]
+    public void DecodingContext_ProviderGuids_IsEmpty_ForTmfOnlyContext()
+    {
+        // TMF files don't contain TMC: records — provider GUIDs cannot be derived from them.
+        IList<DecodingContextType> tmfTypes =
+            TmfFilesDirectoryDecodingContextType.CreateFrom(@".\symbols");
+        DecodingContext context = new(tmfTypes);
+
+        Assert.That(context.ProviderGuids, Is.Empty);
+    }
+
+    [Test]
+    [Category("Parse")]
+    public void DecodingContext_ProviderGuids_DoesNotContainTmfMessageHashGuid()
+    {
+        // KnownGuid (e4b27b5e-...) is a per-source-file TMF message hash, not a control GUID.
+        DecodingContext context =
+            new(PdbFileDecodingContextType.CreateFrom(@".\symbols\BthPS3.pdb"));
+
+        Assert.That(context.ProviderGuids, Does.Not.Contain(KnownGuid));
     }
 }

--- a/tools/Nefarius.Utilities.ETW.RealtimeCli/Program.cs
+++ b/tools/Nefarius.Utilities.ETW.RealtimeCli/Program.cs
@@ -149,8 +149,17 @@ Command inspectPdb = new(
 inspectPdb.SetAction((ParseResult result) =>
 {
     string[] paths = result.GetValue(inspectPathsArg)!;
-    bool useNdjson = result.GetValue(inspectFormatOpt)!
-        .Equals("ndjson", StringComparison.OrdinalIgnoreCase);
+    string formatValue = result.GetValue(inspectFormatOpt)!;
+
+    if (!formatValue.Equals("plain", StringComparison.OrdinalIgnoreCase) &&
+        !formatValue.Equals("ndjson", StringComparison.OrdinalIgnoreCase))
+    {
+        Console.Error.WriteLine(
+            $"[!] Unknown --format value '{formatValue}'. Expected 'plain' or 'ndjson'.");
+        return 1;
+    }
+
+    bool useNdjson = formatValue.Equals("ndjson", StringComparison.OrdinalIgnoreCase);
 
     // Collect PDB contexts only — TMF sources never carry a control GUID.
     List<PdbFileDecodingContextType> pdbContexts = [];
@@ -159,7 +168,7 @@ inspectPdb.SetAction((ParseResult result) =>
     {
         if (arg.Contains('*') || arg.Contains('?'))
         {
-            string root = Path.GetDirectoryName(arg) ?? ".";
+            string root = NormalizeGlobRoot(arg);
             string pattern = Path.GetFileName(arg);
             bool recurse = arg.Contains("**");
             SearchOption search = recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
@@ -440,7 +449,9 @@ static (DecodingContext? Context, List<DecodingContextType> ContextTypes) Resolv
         {
             // Glob pattern: split into directory root + file pattern.
             // Recurse only when the caller explicitly uses ** in the pattern.
-            string root = Path.GetDirectoryName(arg) ?? ".";
+            // NormalizeGlobRoot strips any wildcard-containing directory segments
+            // (e.g. "C:\Symbols\**\*.pdb" → root "C:\Symbols") so Directory.Exists succeeds.
+            string root = NormalizeGlobRoot(arg);
             string pattern = Path.GetFileName(arg);
             bool recurse = arg.Contains("**");
             SearchOption search = recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
@@ -458,12 +469,11 @@ static (DecodingContext? Context, List<DecodingContextType> ContextTypes) Resolv
         }
         else if (Directory.Exists(arg))
         {
-            // Directory: collect all PDB files recursively and treat the directory
-            // itself as a TMF search path (TmfFilesDirectoryDecodingContextType parses
-            // every *.tmf inside it).
+            // Directory: collect all PDB files recursively (AllDirectories so subdirectories
+            // are included — each PDB is loaded individually so recursion is safe).
             bool anyFound = false;
 
-            foreach (string pdb in Directory.EnumerateFiles(arg, "*.pdb", SearchOption.TopDirectoryOnly))
+            foreach (string pdb in Directory.EnumerateFiles(arg, "*.pdb", SearchOption.AllDirectories))
             {
                 if (AddSymbolFile(contexts, pdb))
                 {
@@ -471,19 +481,25 @@ static (DecodingContext? Context, List<DecodingContextType> ContextTypes) Resolv
                 }
             }
 
-            // Only add the directory as a TMF source when it actually contains TMF files,
-            // so we don't waste time on symbol-only directories.
-            if (Directory.EnumerateFiles(arg, "*.tmf", SearchOption.TopDirectoryOnly).Any())
+            // For TMF: TmfFilesDirectoryDecodingContextType scans a flat directory, so add
+            // each directory that *directly* contains .tmf files as a separate source.
+            // Using AllDirectories in the file search lets us discover TMF dirs in subdirs too.
+            IEnumerable<string> tmfDirs = Directory
+                .EnumerateFiles(arg, "*.tmf", SearchOption.AllDirectories)
+                .Select(f => Path.GetDirectoryName(f)!)
+                .Distinct();
+
+            foreach (string tmfDir in tmfDirs)
             {
                 try
                 {
-                    contexts.Add(new TmfFilesDirectoryDecodingContextType(arg));
-                    Console.Error.WriteLine($"    + {arg} (TMF directory)");
+                    contexts.Add(new TmfFilesDirectoryDecodingContextType(tmfDir));
+                    Console.Error.WriteLine($"    + {tmfDir} (TMF directory)");
                     anyFound = true;
                 }
                 catch (Exception ex)
                 {
-                    Console.Error.WriteLine($"[!] Failed to load TMF directory '{arg}': {ex.Message}");
+                    Console.Error.WriteLine($"[!] Failed to load TMF directory '{tmfDir}': {ex.Message}");
                 }
             }
 
@@ -544,6 +560,31 @@ static bool AddSymbolFile(List<DecodingContextType> contexts, string path)
         Console.Error.WriteLine($"[!] Failed to load '{path}': {ex.Message}");
         return false;
     }
+}
+
+/// <summary>
+///     Returns the last path-directory segment of <paramref name="globArg" /> that does not
+///     contain any wildcard characters (<c>*</c> or <c>?</c>).
+///     For example, <c>C:\Symbols\**\*.pdb</c> yields <c>C:\Symbols</c> rather than
+///     <c>C:\Symbols\**</c>, which allows <see cref="Directory.Exists" /> to succeed.
+/// </summary>
+static string NormalizeGlobRoot(string globArg)
+{
+    string? dir = Path.GetDirectoryName(globArg);
+    if (string.IsNullOrEmpty(dir)) return ".";
+
+    while (dir.Contains('*') || dir.Contains('?'))
+    {
+        string? parent = Path.GetDirectoryName(dir);
+        if (parent is null || parent.Length == 0 || parent == dir)
+        {
+            return ".";
+        }
+
+        dir = parent;
+    }
+
+    return dir;
 }
 
 /// <summary>

--- a/tools/Nefarius.Utilities.ETW.RealtimeCli/Program.cs
+++ b/tools/Nefarius.Utilities.ETW.RealtimeCli/Program.cs
@@ -1,16 +1,21 @@
 using System.CommandLine;
 using System.Globalization;
+using System.Text.Json;
 
 using Nefarius.Utilities.ETW;
 using Nefarius.Utilities.ETW.Deserializer.WPP;
+using Nefarius.Utilities.ETW.Deserializer.WPP.TMF;
 
 // ---------------------------------------------------------------------------
 // Arguments and options
 // ---------------------------------------------------------------------------
 Argument<Guid[]> providerArg = new("provider-guid")
 {
-    Description = "One or more ETW provider GUIDs to enable (e.g. {12345678-...}). All providers share the same keyword/level filters.",
-    Arity = ArgumentArity.OneOrMore
+    Description =
+        "One or more ETW provider GUIDs to enable (e.g. {12345678-...}). " +
+        "When omitted, provider GUIDs are auto-derived from any PDB files passed to --symbols. " +
+        "All providers share the same keyword/level filters.",
+    Arity = ArgumentArity.ZeroOrMore
 };
 
 Option<string> keywordsOpt = new("--keywords")
@@ -77,7 +82,7 @@ Command realtime = new(
 
 realtime.SetAction(async (ParseResult result, CancellationToken cancellationToken) =>
 {
-    Guid[] providers = result.GetValue(providerArg)!;
+    Guid[] explicitProviders = result.GetValue(providerArg) ?? [];
     string keywordsRaw = result.GetValue(keywordsOpt)!;
     string matchAllRaw = result.GetValue(matchAllOpt)!;
     TraceEventLevel level = result.GetValue(levelOpt);
@@ -102,7 +107,7 @@ realtime.SetAction(async (ParseResult result, CancellationToken cancellationToke
     }
 
     return await RunAsync(
-        providers,
+        explicitProviders,
         matchAny,
         matchAll,
         level,
@@ -114,11 +119,149 @@ realtime.SetAction(async (ParseResult result, CancellationToken cancellationToke
 });
 
 // ---------------------------------------------------------------------------
+// 'inspect-pdb' subcommand
+// ---------------------------------------------------------------------------
+Argument<string[]> inspectPathsArg = new("path")
+{
+    Description =
+        "One or more paths to .pdb files, directories (searched for *.pdb), " +
+        "or glob patterns (e.g. C:\\Symbols\\*.pdb). TMF files are ignored as they do not " +
+        "contain WPP control GUID information.",
+    Arity = ArgumentArity.OneOrMore
+};
+
+Option<string> inspectFormatOpt = new("--format")
+{
+    Description = "Output format: 'plain' (default) or 'ndjson'.",
+    DefaultValueFactory = _ => "plain"
+};
+
+Command inspectPdb = new(
+    "inspect-pdb",
+    "Parse one or more PDB files and list the WPP provider GUIDs (control GUIDs) embedded in " +
+    "them via TMC: annotations. No ETW session is created. Output goes to stdout; status messages " +
+    "go to stderr.")
+{
+    inspectPathsArg,
+    inspectFormatOpt
+};
+
+inspectPdb.SetAction((ParseResult result) =>
+{
+    string[] paths = result.GetValue(inspectPathsArg)!;
+    bool useNdjson = result.GetValue(inspectFormatOpt)!
+        .Equals("ndjson", StringComparison.OrdinalIgnoreCase);
+
+    // Collect PDB contexts only — TMF sources never carry a control GUID.
+    List<PdbFileDecodingContextType> pdbContexts = [];
+
+    foreach (string arg in paths)
+    {
+        if (arg.Contains('*') || arg.Contains('?'))
+        {
+            string root = Path.GetDirectoryName(arg) ?? ".";
+            string pattern = Path.GetFileName(arg);
+            bool recurse = arg.Contains("**");
+            SearchOption search = recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+
+            if (!Directory.Exists(root))
+            {
+                Console.Error.WriteLine($"[!] Glob root directory not found: {root}");
+                continue;
+            }
+
+            foreach (string file in Directory.EnumerateFiles(root, pattern, search))
+            {
+                TryAddPdb(pdbContexts, file);
+            }
+        }
+        else if (Directory.Exists(arg))
+        {
+            bool any = false;
+            foreach (string pdb in Directory.EnumerateFiles(arg, "*.pdb", SearchOption.TopDirectoryOnly))
+            {
+                if (TryAddPdb(pdbContexts, pdb)) { any = true; }
+            }
+
+            if (!any)
+            {
+                Console.Error.WriteLine($"[!] No PDB files found in directory: {arg}");
+            }
+        }
+        else if (File.Exists(arg))
+        {
+            TryAddPdb(pdbContexts, arg);
+        }
+        else
+        {
+            Console.Error.WriteLine($"[!] Path not found: {arg}");
+        }
+    }
+
+    if (pdbContexts.Count == 0)
+    {
+        Console.Error.WriteLine("[!] No PDB files could be loaded.");
+        return 1;
+    }
+
+    // Collect all TMC records across every loaded PDB.
+    List<WppTraceControl> allControls = pdbContexts
+        .SelectMany(ctx => ctx.WppTraceControls)
+        .DistinctBy(c => c.ControlGuid)
+        .OrderBy(c => c.Name)
+        .ThenBy(c => c.ControlGuid)
+        .ToList();
+
+    if (allControls.Count == 0)
+    {
+        Console.Error.WriteLine(
+            "[!] No WPP control GUIDs (TMC: annotations) found in the supplied PDB files. " +
+            "The PDB must have been compiled with WPP tracing enabled.");
+        return 1;
+    }
+
+    if (useNdjson)
+    {
+        JsonSerializerOptions jsonOpts = new() { WriteIndented = false };
+        foreach (WppTraceControl ctrl in allControls)
+        {
+            string json = JsonSerializer.Serialize(new
+            {
+                guid = ctrl.ControlGuid.ToString("B").ToUpperInvariant(),
+                name = ctrl.Name,
+                bitFlags = ctrl.BitFlags,
+                source = ctrl.OriginalSymbolFileName ?? string.Empty
+            }, jsonOpts);
+            Console.WriteLine(json);
+        }
+    }
+    else
+    {
+        foreach (WppTraceControl ctrl in allControls)
+        {
+            string source = ctrl.OriginalSymbolFileName ?? "unknown";
+            Console.WriteLine(
+                $"{ctrl.ControlGuid.ToString("B").ToUpperInvariant(),-42}  " +
+                $"{ctrl.Name,-30}  " +
+                $"({source}, {ctrl.BitFlags.Count} bit flags)");
+
+            foreach (string flag in ctrl.BitFlags)
+            {
+                Console.WriteLine($"    {flag}");
+            }
+        }
+    }
+
+    return 0;
+});
+
+// ---------------------------------------------------------------------------
 // Root command
 // ---------------------------------------------------------------------------
 RootCommand root = new("realtimewpp — Nefarius ETW realtime decoder. Streams decoded events as NDJSON on stdout.")
 {
-    realtime
+    realtime,
+    inspectPdb
 };
 
 return await root.Parse(args).InvokeAsync();
@@ -139,7 +282,7 @@ static ulong ParseKeywordMask(string raw)
 }
 
 static async Task<int> RunAsync(
-    Guid[] providerGuids,
+    Guid[] explicitProviderGuids,
     ulong matchAnyKeyword,
     ulong matchAllKeyword,
     TraceEventLevel level,
@@ -149,8 +292,45 @@ static async Task<int> RunAsync(
     uint flushSeconds,
     CancellationToken cancellationToken)
 {
-    // Resolve --symbols paths into a DecodingContext (null when no symbols supplied).
-    DecodingContext? decodingContext = ResolveSymbols(symbolPaths);
+    // Resolve --symbols paths into a DecodingContext and the raw context list.
+    (DecodingContext? decodingContext, List<DecodingContextType> contextTypes) = ResolveSymbols(symbolPaths);
+
+    // Determine the final provider list: explicit args take precedence; fall back to WPP control
+    // GUIDs extracted from TMC: annotations in the PDB files.
+    Guid[] providerGuids;
+    bool autoderived = false;
+    if (explicitProviderGuids.Length > 0)
+    {
+        providerGuids = explicitProviderGuids;
+    }
+    else
+    {
+        providerGuids = contextTypes
+            .SelectMany(t => t.ProviderGuids)
+            .Distinct()
+            .ToArray();
+        autoderived = providerGuids.Length > 0;
+    }
+
+    if (providerGuids.Length == 0)
+    {
+        if (symbolPaths.Length > 0)
+        {
+            Console.Error.WriteLine(
+                "[!] No provider GUIDs could be derived from the supplied --symbols paths. " +
+                "Only PDB files carry WPP control GUID information (TMC: annotations). " +
+                "TMF files alone are not sufficient — either pass a PDB file or supply the " +
+                "provider-guid argument explicitly.");
+        }
+        else
+        {
+            Console.Error.WriteLine(
+                "[!] No provider GUIDs available. Supply at least one provider-guid argument, " +
+                "or pass --symbols with one or more PDB files containing WPP annotations.");
+        }
+
+        return 2;
+    }
 
     // Build a linked CTS so both Ctrl+C and the caller's token can cancel.
     using CancellationTokenSource cts =
@@ -195,9 +375,10 @@ static async Task<int> RunAsync(
             session.EnableProvider(guid, level, matchAnyKeyword, matchAllKeyword);
         }
 
+        string providerSource = autoderived ? "auto-derived from symbols" : "explicit";
         Console.Error.WriteLine(
             $"[*] Session '{sessionName}' started. " +
-            $"Providers: {string.Join(", ", providerGuids.Select(g => $"{{{g}}}"))} | " +
+            $"Providers ({providerSource}): {string.Join(", ", providerGuids.Select(g => $"{{{g}}}"))} | " +
             $"level={level} | keywords=0x{matchAnyKeyword:X} | matchAll=0x{matchAllKeyword:X}");
         Console.Error.WriteLine("[*] Streaming events... (Ctrl+C to stop)");
 
@@ -239,18 +420,19 @@ static async Task<int> RunAsync(
 }
 
 /// <summary>
-///     Converts the raw <c>--symbols</c> arguments into a <see cref="DecodingContext" />.
-///     Returns <see langword="null" /> when no symbol paths were supplied, which disables
-///     WPP message formatting (raw events are still decoded via TDH/manifest).
+///     Converts the raw <c>--symbols</c> arguments into a <see cref="DecodingContext" /> and the
+///     underlying list of <see cref="DecodingContextType" />s.
+///     Returns a <see langword="null" /> context when no symbol paths were supplied or none could
+///     be loaded, which disables WPP message formatting (raw events are still decoded via TDH/manifest).
 /// </summary>
-static DecodingContext? ResolveSymbols(string[] symbolPaths)
+static (DecodingContext? Context, List<DecodingContextType> ContextTypes) ResolveSymbols(string[] symbolPaths)
 {
+    List<DecodingContextType> contexts = [];
+
     if (symbolPaths.Length == 0)
     {
-        return null;
+        return (null, contexts);
     }
-
-    List<DecodingContextType> contexts = [];
 
     foreach (string arg in symbolPaths)
     {
@@ -323,11 +505,11 @@ static DecodingContext? ResolveSymbols(string[] symbolPaths)
     if (contexts.Count == 0)
     {
         Console.Error.WriteLine("[!] No symbol files could be loaded; WPP messages will not be decoded.");
-        return null;
+        return (null, contexts);
     }
 
     Console.Error.WriteLine($"[*] Loaded {contexts.Count} symbol source(s) for WPP decoding.");
-    return new DecodingContext(contexts);
+    return (new DecodingContext(contexts), contexts);
 }
 
 /// <summary>
@@ -356,6 +538,32 @@ static bool AddSymbolFile(List<DecodingContextType> contexts, string path)
 
         Console.Error.WriteLine($"[!] Unrecognized symbol file type (expected .pdb or .tmf): {path}");
         return false;
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"[!] Failed to load '{path}': {ex.Message}");
+        return false;
+    }
+}
+
+/// <summary>
+///     Attempts to parse a file as a PDB and add it to the <paramref name="pdbContexts" /> list.
+///     Only accepts files with a <c>.pdb</c> extension; silently skips anything else.
+///     Returns <see langword="true" /> if the file was loaded successfully.
+/// </summary>
+static bool TryAddPdb(List<PdbFileDecodingContextType> pdbContexts, string path)
+{
+    if (!Path.GetExtension(path).Equals(".pdb", StringComparison.OrdinalIgnoreCase))
+    {
+        return false;
+    }
+
+    try
+    {
+        PdbFileDecodingContextType ctx = new(path);
+        pdbContexts.Add(ctx);
+        Console.Error.WriteLine($"    + {path}");
+        return true;
     }
     catch (Exception ex)
     {

--- a/tools/Nefarius.Utilities.ETW.RealtimeCli/Program.cs
+++ b/tools/Nefarius.Utilities.ETW.RealtimeCli/Program.cs
@@ -168,6 +168,12 @@ inspectPdb.SetAction((ParseResult result) =>
     {
         if (arg.Contains('*') || arg.Contains('?'))
         {
+            if (ValidateGlobPattern(arg) is string validationError)
+            {
+                Console.Error.WriteLine(validationError);
+                continue;
+            }
+
             string root = NormalizeGlobRoot(arg);
             string pattern = Path.GetFileName(arg);
             bool recurse = arg.Contains("**");
@@ -449,8 +455,14 @@ static (DecodingContext? Context, List<DecodingContextType> ContextTypes) Resolv
         {
             // Glob pattern: split into directory root + file pattern.
             // Recurse only when the caller explicitly uses ** in the pattern.
-            // NormalizeGlobRoot strips any wildcard-containing directory segments
-            // (e.g. "C:\Symbols\**\*.pdb" → root "C:\Symbols") so Directory.Exists succeeds.
+            // NormalizeGlobRoot strips the standalone ** segment so Directory.Exists succeeds.
+            // Reject before calling NormalizeGlobRoot so no filter is silently lost.
+            if (ValidateGlobPattern(arg) is string validationError)
+            {
+                Console.Error.WriteLine(validationError);
+                continue;
+            }
+
             string root = NormalizeGlobRoot(arg);
             string pattern = Path.GetFileName(arg);
             bool recurse = arg.Contains("**");
@@ -560,6 +572,39 @@ static bool AddSymbolFile(List<DecodingContextType> contexts, string path)
         Console.Error.WriteLine($"[!] Failed to load '{path}': {ex.Message}");
         return false;
     }
+}
+
+/// <summary>
+///     Validates that a glob pattern does not contain wildcard characters inside any directory
+///     segment except the standalone <c>**</c> recursion marker.
+///     Returns a non-null, ready-to-print error message when the pattern is invalid;
+///     returns <see langword="null" /> when the pattern is acceptable.
+/// </summary>
+/// <remarks>
+///     Allowed: <c>C:\Symbols\*.pdb</c> (filename wildcard) and
+///     <c>C:\Symbols\**\*.pdb</c> (standalone <c>**</c> recursion marker).
+///     Rejected: <c>C:\Sym*\*.pdb</c> or <c>C:\Symbols\sub?\*.pdb</c>
+///     (wildcards in a non-terminal, non-<c>**</c> directory segment).
+/// </remarks>
+static string? ValidateGlobPattern(string globArg)
+{
+    string[] segments = globArg.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
+
+    // Every segment except the last is a directory segment.
+    for (int i = 0; i < segments.Length - 1; i++)
+    {
+        string seg = segments[i];
+        if (seg == "**") { continue; } // recursion marker — explicitly allowed
+
+        if (seg.Contains('*') || seg.Contains('?'))
+        {
+            return $"[!] Wildcard in directory segment '{seg}' is not supported in '{globArg}'. " +
+                   $"Use a filename-only wildcard (e.g. *.pdb) or '**' for recursion " +
+                   $"(e.g. Symbols\\**\\*.pdb).";
+        }
+    }
+
+    return null;
 }
 
 /// <summary>

--- a/tools/Nefarius.Utilities.ETW.RealtimeCli/Program.cs
+++ b/tools/Nefarius.Utilities.ETW.RealtimeCli/Program.cs
@@ -610,7 +610,10 @@ static string? ValidateGlobPattern(string globArg)
     // The last segment is the filename pattern passed to Directory.EnumerateFiles as
     // searchPattern. "**" and empty are not valid searchPattern values and would throw
     // ArgumentException at runtime; reject them here with a clear message.
-    string lastSeg = segments.Length > 0 ? segments[^1] : string.Empty;
+    // Use Path.GetFileName rather than segments[^1] so that a trailing separator
+    // (e.g. "C:\Symbols\*.pdb\") is detected: Split(..., RemoveEmptyEntries) silently
+    // drops the trailing empty segment, but Path.GetFileName returns "" in that case.
+    string lastSeg = Path.GetFileName(globArg);
     if (lastSeg == "**" || lastSeg.Length == 0)
     {
         return $"[!] Glob pattern '{globArg}' has no filename component. " +

--- a/tools/Nefarius.Utilities.ETW.RealtimeCli/Program.cs
+++ b/tools/Nefarius.Utilities.ETW.RealtimeCli/Program.cs
@@ -585,6 +585,9 @@ static bool AddSymbolFile(List<DecodingContextType> contexts, string path)
 ///     <c>C:\Symbols\**\*.pdb</c> (standalone <c>**</c> recursion marker).
 ///     Rejected: <c>C:\Sym*\*.pdb</c> or <c>C:\Symbols\sub?\*.pdb</c>
 ///     (wildcards in a non-terminal, non-<c>**</c> directory segment).
+///     Also rejected: <c>C:\Symbols\**</c> or a trailing separator — patterns
+///     with no filename component produce an invalid <c>searchPattern</c> for
+///     <see cref="Directory.EnumerateFiles" />.
 /// </remarks>
 static string? ValidateGlobPattern(string globArg)
 {
@@ -602,6 +605,17 @@ static string? ValidateGlobPattern(string globArg)
                    $"Use a filename-only wildcard (e.g. *.pdb) or '**' for recursion " +
                    $"(e.g. Symbols\\**\\*.pdb).";
         }
+    }
+
+    // The last segment is the filename pattern passed to Directory.EnumerateFiles as
+    // searchPattern. "**" and empty are not valid searchPattern values and would throw
+    // ArgumentException at runtime; reject them here with a clear message.
+    string lastSeg = segments.Length > 0 ? segments[^1] : string.Empty;
+    if (lastSeg == "**" || lastSeg.Length == 0)
+    {
+        return $"[!] Glob pattern '{globArg}' has no filename component. " +
+               $"Use a filename wildcard (e.g. *.pdb) or '**' with a filename " +
+               $"(e.g. Symbols\\**\\*.pdb).";
     }
 
     return null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-derive WPP provider GUIDs from supplied PDB symbols (explicit GUIDs still take precedence); CLI now indicates explicit vs. auto-derived and accepts symbol globs/directories recursively.
  * `--provider-guid` made optional.
  * New inspect-pdb command to list WPP control GUIDs in plain or NDJSON.

* **Documentation**
  * README/CLI docs expanded with examples for auto-derived providers, symbol globs, inspect-pdb, and TMF-only guidance; NDJSON example updated.

* **Tests**
  * Added tests covering PDB trace-control and provider GUID enumeration and related behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/Nefarius.Utilities.ETW/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->