### PR TITLE
Add WPP-native identifier aliases to filter compilation

### DIFF
--- a/tools/Nefarius.Utilities.ETW.CLI/PlainOutput.cs
+++ b/tools/Nefarius.Utilities.ETW.CLI/PlainOutput.cs
@@ -199,9 +199,11 @@ internal static class PlainOutput
             // property exposed as a separate Parameter<T>, then build a Func<PlainEvent,bool>
             // wrapper that unpacks the record and calls the inner delegate.
 
-            // Build typed parameters for every exposed property.
+            // Primary column-token parameters (used by --columns and --filter alike).
+            // WPP-native aliases follow so users can write either GuidName or Provider, etc.
             Parameter[] propertyParams =
             [
+                // Column tokens
                 new Parameter("Timestamp",         typeof(string)),
                 new Parameter("Provider",          typeof(string)),
                 new Parameter("ProviderGuid",      typeof(string)),
@@ -219,6 +221,15 @@ internal static class PlainOutput
                 new Parameter("Component",         typeof(string)),
                 new Parameter("SubComponent",      typeof(string)),
                 new Parameter("Flags",             typeof(string)),
+
+                // WPP-native aliases — identical values, raw JSON property names
+                new Parameter("GuidName",          typeof(string)),  // == Provider
+                new Parameter("LevelName",         typeof(string)),  // == Level
+                new Parameter("FormattedString",   typeof(string)),  // == Message
+                new Parameter("FunctionName",      typeof(string)),  // == Function
+                new Parameter("ComponentName",     typeof(string)),  // == Component
+                new Parameter("SubComponentName",  typeof(string)),  // == SubComponent
+                new Parameter("FlagsName",         typeof(string)),  // == Flags
             ];
 
             // Parse the expression into a Lambda, constraining the return type to bool so that
@@ -233,6 +244,7 @@ internal static class PlainOutput
             }
 
             Func<PlainEvent, bool> predicate = (PlainEvent evt) => (bool)parsed.Invoke(
+                // Column tokens
                 evt.Timestamp,
                 evt.Provider,
                 evt.ProviderGuid,
@@ -249,7 +261,15 @@ internal static class PlainOutput
                 evt.Function,
                 evt.Component,
                 evt.SubComponent,
-                evt.Flags
+                evt.Flags,
+                // WPP-native aliases
+                evt.Provider,      // GuidName
+                evt.Level,         // LevelName
+                evt.Message,       // FormattedString
+                evt.Function,      // FunctionName
+                evt.Component,     // ComponentName
+                evt.SubComponent,  // SubComponentName
+                evt.Flags          // FlagsName
             )!;
 
             error = null;

--- a/tools/Nefarius.Utilities.ETW.CLI/README.md
+++ b/tools/Nefarius.Utilities.ETW.CLI/README.md
@@ -387,3 +387,12 @@ All column tokens listed above are available as identifiers directly in the expr
 
 - [GitHub repository](https://github.com/nefarius/Nefarius.Utilities.ETW)
 - [Nefarius.Utilities.ETW library on NuGet](https://www.nuget.org/packages/Nefarius.Utilities.ETW/)
+
+## Credits
+
+| Package | Author / Maintainer | License | Role |
+|---|---|---|---|
+| [DynamicExpresso.Core](https://github.com/dynamicexpresso/DynamicExpresso) | Davide Icardi | MIT | Powers the `--filter` predicate engine |
+| [System.CommandLine](https://github.com/dotnet/command-line-api) | .NET Foundation | MIT | CLI argument parsing, help generation, and tab-completion plumbing |
+| [Smx.PDBSharp](https://github.com/smx-smx/PDBSharp) | smx-smx | MPL-2.0 | PDB file parsing used by `inspect-pdb` and WPP symbol resolution |
+| [MinVer](https://github.com/adamralph/minver) | Adam Ralph | Apache-2.0 | Build-time Git-tag-based version stamping (not shipped at runtime) |

--- a/tools/Nefarius.Utilities.ETW.CLI/README.md
+++ b/tools/Nefarius.Utilities.ETW.CLI/README.md
@@ -344,19 +344,34 @@ When stdout is a TTY (and `NO_COLOR` is not set), the `Level` column (when prese
 
 #### Filter expression language
 
-`--filter` accepts a C#-like boolean expression evaluated per event by [DynamicExpresso](https://github.com/dynamicexpresso/DynamicExpresso). Events for which the expression returns `false` are silently dropped. Parse errors abort startup with exit code 2; per-event evaluation errors are logged to stderr and drop the event (non-fatal).
+`--filter` accepts a C#-like boolean expression evaluated per event by [DynamicExpresso](https://github.com/dynamicexpresso/DynamicExpresso). Events for which the expression returns `false` are silently dropped. Parse errors abort startup with exit code 2; per-event evaluation errors are fatal.
 
-All column tokens listed above are available as identifiers directly in the expression (no prefix needed):
+All column tokens listed above are available as identifiers directly in the expression (no prefix needed). In addition, the raw WPP JSON property names are accepted as aliases so you can use either form interchangeably:
+
+| Raw WPP name | Alias for |
+|---|---|
+| `GuidName` | `Provider` |
+| `LevelName` | `Level` |
+| `FormattedString` | `Message` |
+| `FunctionName` | `Function` |
+| `ComponentName` | `Component` |
+| `SubComponentName` | `SubComponent` |
+| `FlagsName` | `Flags` |
 
 ```text
-# Skip all events from a specific provider
+# Skip all events from a specific provider (column token or WPP alias both work)
 --filter "Provider != \"BthPS3PSM\""
+--filter "GuidName != \"BthPS3PSM\""
 
-# Only show errors and above (LevelNumber <= 3 covers Critical, Error, Warning)
---filter "LevelNumber <= 3 && LevelNumber > 0"
+# Only show errors and warnings (Error=2, Warning=3)
+--filter "LevelNumber == 2 || LevelNumber == 3"
 
 # Keep only events whose message starts with a specific string
 --filter "Message.StartsWith(\"[BthPS3\")"
+--filter "FormattedString.StartsWith(\"[BthPS3\")"
+
+# Filter by WPP function name
+--filter "FunctionName.StartsWith(\"EvtUdecx\")"
 
 # Combine conditions
 --filter "Provider == \"BthPS3\" && !Message.Contains(\"Verbose\")"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Filter expressions now support additional property aliases (GuidName, LevelName, FormattedString, FunctionName, ComponentName, SubComponentName, FlagsName).
  * Filter evaluation errors are now treated as fatal for clearer behavior.

* **Documentation**
  * Updated filter documentation with alias mappings and practical examples.
  * Added Credits section acknowledging project dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/Nefarius.Utilities.ETW/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->