### PR TITLE
Added new `verbose` CLI command

### DIFF
--- a/tools/Nefarius.Utilities.ETW.CLI/Nefarius.Utilities.ETW.CLI.csproj
+++ b/tools/Nefarius.Utilities.ETW.CLI/Nefarius.Utilities.ETW.CLI.csproj
@@ -45,7 +45,8 @@
         <None Include="README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
-    <ItemGroup>        
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
         <PackageReference Include="DynamicExpresso.Core" Version="2.19.3" />
         <!--
             Smx.PDBSharp is pinned to 1.0.0-alpha4 because no stable release exists on NuGet.org

--- a/tools/Nefarius.Utilities.ETW.CLI/Program.cs
+++ b/tools/Nefarius.Utilities.ETW.CLI/Program.cs
@@ -646,13 +646,211 @@ parse.SetAction(async (ParseResult result, CancellationToken cancellationToken) 
 });
 
 // ---------------------------------------------------------------------------
+// 'verbose' subcommand – arguments and options
+// ---------------------------------------------------------------------------
+Argument<string> verboseServiceArg = new("service-name")
+{
+    Description = "Name of the driver service to target (e.g. BthPS3)."
+};
+
+Option<bool> verboseEnableOpt = new("--enable")
+{
+    Description = "Set VerboseOn = 1 in the driver service's Parameters key."
+};
+
+Option<bool> verboseDisableOpt = new("--disable")
+{
+    Description = "Delete the VerboseOn value from the driver service's Parameters key."
+};
+
+Option<bool> verboseStatusOpt = new("--status")
+{
+    Description = "Show the current VerboseOn state for the service without making changes."
+};
+
+Option<string?> verboseTypeOpt = new("--type")
+{
+    Description =
+        "Target a specific driver kind: 'kernel' or 'umdf'. " +
+        "When omitted the command prefers a kernel-mode service and falls back to UMDF with a warning."
+};
+
+Option<bool> verboseDryRunOpt = new("--dry-run")
+{
+    Description = "Print what would be done without touching the registry. Exits with code 0."
+};
+
+Command verbose = new(
+    "verbose",
+    "Enable or disable WPP verbose tracing for a kernel-mode or UMDF driver service by " +
+    "writing the VerboseOn REG_DWORD under the service's Parameters key. " +
+    "Requires an elevated (admin) process for --enable and --disable.")
+{
+    verboseServiceArg,
+    verboseEnableOpt,
+    verboseDisableOpt,
+    verboseStatusOpt,
+    verboseTypeOpt,
+    verboseDryRunOpt
+};
+
+verbose.SetAction((ParseResult result) =>
+{
+    string serviceName = result.GetValue(verboseServiceArg)!;
+    bool   doEnable    = result.GetValue(verboseEnableOpt);
+    bool   doDisable   = result.GetValue(verboseDisableOpt);
+    bool   doStatus    = result.GetValue(verboseStatusOpt);
+    string? typeRaw    = result.GetValue(verboseTypeOpt);
+    bool   dryRun      = result.GetValue(verboseDryRunOpt);
+
+    // --- Validate mutually exclusive action flags ---
+    int actionCount = (doEnable ? 1 : 0) + (doDisable ? 1 : 0) + (doStatus ? 1 : 0);
+    if (actionCount == 0)
+    {
+        Console.Error.WriteLine("[!] One of --enable, --disable, or --status is required.");
+        return 2;
+    }
+
+    if (actionCount > 1)
+    {
+        Console.Error.WriteLine("[!] Only one of --enable, --disable, or --status may be specified at a time.");
+        return 2;
+    }
+
+    // --- Validate --type ---
+    ServiceKind? requestedKind = null;
+    if (typeRaw is not null)
+    {
+        if (typeRaw.Equals("kernel", StringComparison.OrdinalIgnoreCase))
+        {
+            requestedKind = ServiceKind.Kernel;
+        }
+        else if (typeRaw.Equals("umdf", StringComparison.OrdinalIgnoreCase))
+        {
+            requestedKind = ServiceKind.Umdf;
+        }
+        else
+        {
+            Console.Error.WriteLine(
+                $"[!] Unknown --type value '{typeRaw}'. Expected 'kernel' or 'umdf'.");
+            return 2;
+        }
+    }
+
+    // --- Detect kernel and UMDF candidates ---
+    DetectionResult detection;
+    try
+    {
+        detection = VerboseRegistry.Detect(serviceName);
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"[!] Registry probe failed: {ex.GetType().Name}: {ex.Message}");
+        return 1;
+    }
+
+    // --- Status: always show both probes and exit ---
+    if (doStatus)
+    {
+        string kernelStatus = detection.Kernel is null
+            ? "absent"
+            : $"present (VerboseOn={(detection.Kernel.CurrentValue.HasValue ? detection.Kernel.CurrentValue.Value.ToString() : "<not set>")})";
+
+        string umdfStatus = detection.Umdf is null
+            ? "absent"
+            : $"present (VerboseOn={(detection.Umdf.CurrentValue.HasValue ? detection.Umdf.CurrentValue.Value.ToString() : "<not set>")})";
+
+        Console.WriteLine($"status: {serviceName}  kernel={kernelStatus}  umdf={umdfStatus}");
+        return 0;
+    }
+
+    // --- Resolve the target candidate for enable/disable ---
+    Candidate? target;
+
+    if (requestedKind is not null)
+    {
+        target = requestedKind == ServiceKind.Kernel ? detection.Kernel : detection.Umdf;
+
+        if (target is null)
+        {
+            Console.Error.WriteLine(
+                $"[!] Service '{serviceName}' was not found as a {requestedKind.Value.ToString().ToLowerInvariant()} driver service.");
+            return 2;
+        }
+    }
+    else
+    {
+        if (detection.Kernel is not null)
+        {
+            target = detection.Kernel;
+        }
+        else if (detection.Umdf is not null)
+        {
+            Console.Error.WriteLine(
+                $"[*] No kernel-mode service named '{serviceName}' found; falling back to UMDF service. " +
+                "Use --type kernel|umdf to silence this warning.");
+            target = detection.Umdf;
+        }
+        else
+        {
+            Console.Error.WriteLine(
+                $"[!] Service '{serviceName}' was not found as a kernel driver or UMDF driver service.");
+            return 2;
+        }
+    }
+
+    string kindLabel   = target.Kind == ServiceKind.Kernel ? "kernel" : "umdf";
+    string actionLabel = doEnable ? "enable" : "disable";
+    string targetPath  = $@"HKLM\{target.TargetKeyPath}\VerboseOn";
+
+    if (dryRun)
+    {
+        Console.Error.WriteLine($"[*] Dry run — would {actionLabel}: {targetPath} ({kindLabel})");
+        Console.WriteLine($"would {actionLabel} VerboseOn at {targetPath} ({kindLabel})");
+        return 0;
+    }
+
+    try
+    {
+        if (doEnable)
+        {
+            VerboseRegistry.Enable(target);
+            Console.Error.WriteLine($"[*] Enabled VerboseOn at {targetPath} ({kindLabel})");
+            Console.WriteLine($"enabled VerboseOn at {targetPath} ({kindLabel})");
+        }
+        else
+        {
+            VerboseRegistry.Disable(target);
+            Console.Error.WriteLine($"[*] Disabled VerboseOn at {targetPath} ({kindLabel})");
+            Console.WriteLine($"disabled VerboseOn at {targetPath} ({kindLabel})");
+        }
+    }
+    catch (UnauthorizedAccessException)
+    {
+        Console.Error.WriteLine(
+            $"[!] Access denied writing to {targetPath}. " +
+            "Run etwutils as Administrator.");
+        return 2;
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine(
+            $"[!] Registry write failed: {ex.GetType().Name}: {ex.Message}");
+        return 1;
+    }
+
+    return 0;
+});
+
+// ---------------------------------------------------------------------------
 // Root command
 // ---------------------------------------------------------------------------
 RootCommand root = new("etwutils — ETW event decoder and offline trace parser. Stream realtime events or decode .etl files as NDJSON on stdout.")
 {
     realtime,
     inspectPdb,
-    parse
+    parse,
+    verbose
 };
 
 return await root.Parse(args).InvokeAsync();

--- a/tools/Nefarius.Utilities.ETW.CLI/Program.cs
+++ b/tools/Nefarius.Utilities.ETW.CLI/Program.cs
@@ -655,12 +655,16 @@ Argument<string> verboseServiceArg = new("service-name")
 
 Option<bool> verboseEnableOpt = new("--enable")
 {
-    Description = "Set VerboseOn = 1 in the driver service's Parameters key."
+    Description =
+        "Set VerboseOn = 1 (REG_DWORD) in the driver service's registry key " +
+        "(Parameters subkey for kernel-mode; service key directly for UMDF)."
 };
 
 Option<bool> verboseDisableOpt = new("--disable")
 {
-    Description = "Delete the VerboseOn value from the driver service's Parameters key."
+    Description =
+        "Delete the VerboseOn value from the driver service's registry key " +
+        "(Parameters subkey for kernel-mode; service key directly for UMDF)."
 };
 
 Option<bool> verboseStatusOpt = new("--status")
@@ -683,7 +687,7 @@ Option<bool> verboseDryRunOpt = new("--dry-run")
 Command verbose = new(
     "verbose",
     "Enable or disable WPP verbose tracing for a kernel-mode or UMDF driver service by " +
-    "writing the VerboseOn REG_DWORD under the service's Parameters key. " +
+    "writing the VerboseOn REG_DWORD to the driver's registry key. " +
     "Requires an elevated (admin) process for --enable and --disable.")
 {
     verboseServiceArg,
@@ -702,6 +706,22 @@ verbose.SetAction((ParseResult result) =>
     bool   doStatus    = result.GetValue(verboseStatusOpt);
     string? typeRaw    = result.GetValue(verboseTypeOpt);
     bool   dryRun      = result.GetValue(verboseDryRunOpt);
+
+    // --- Validate service name ---
+    if (string.IsNullOrWhiteSpace(serviceName))
+    {
+        Console.Error.WriteLine("[!] service-name must not be empty or whitespace.");
+        return 2;
+    }
+
+    // Reject path separators and common invalid registry key characters to prevent
+    // a caller from composing registry paths outside the expected service subtree.
+    if (serviceName.IndexOfAny(['\\', '/', '\0']) >= 0)
+    {
+        Console.Error.WriteLine(
+            "[!] service-name must not contain path separators ('\\', '/') or null characters.");
+        return 2;
+    }
 
     // --- Validate mutually exclusive action flags ---
     int actionCount = (doEnable ? 1 : 0) + (doDisable ? 1 : 0) + (doStatus ? 1 : 0);

--- a/tools/Nefarius.Utilities.ETW.CLI/README.md
+++ b/tools/Nefarius.Utilities.ETW.CLI/README.md
@@ -99,6 +99,65 @@ etwutils realtime [<provider-guid> ...]
 
 > **Note:** Auto-derivation requires **PDB files**. TMF files do not contain the WPP control GUID (they only hold per-call-site message format data). If `--symbols` points to a directory or glob that contains only TMF files, you must also supply `provider-guid` explicitly.
 
+### `verbose`
+
+Enable or disable WPP verbose tracing for a kernel-mode or UMDF driver service by writing the `VerboseOn` `REG_DWORD` under the driver's registry parameters key.
+
+> **Admin required.** `--enable` and `--disable` write to `HKEY_LOCAL_MACHINE` and require an elevated process.
+
+```text
+etwutils verbose <service-name>
+    (--enable | --disable | --status)
+    [--type kernel|umdf]
+    [--dry-run]
+```
+
+| Option | Description |
+|---|---|
+| `--enable` | Write `VerboseOn = 1` (REG_DWORD) to the service's Parameters key |
+| `--disable` | Delete the `VerboseOn` value (silent no-op when already absent) |
+| `--status` | Print the current state for both kernel and UMDF candidates; no registry writes |
+| `--type kernel\|umdf` | Target a specific driver kind explicitly (see detection rules below) |
+| `--dry-run` | Print what would be done without touching the registry; exits 0 |
+
+#### Registry target paths
+
+| Driver kind | `VerboseOn` location |
+|---|---|
+| Kernel-mode | `HKLM\SYSTEM\CurrentControlSet\Services\<name>\Parameters\VerboseOn` |
+| UMDF | `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WUDF\Services\<name>\VerboseOn` |
+
+#### Service detection rules
+
+The command probes both registry locations independently for the given service name:
+
+- **Kernel candidate** — `HKLM\SYSTEM\CurrentControlSet\Services\<name>\Type` must exist and equal `SERVICE_KERNEL_DRIVER` (1) or `SERVICE_FILE_SYSTEM_DRIVER` (2). Any other `Type` value is not treated as a kernel candidate.
+- **UMDF candidate** — the key `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WUDF\Services\<name>` must exist.
+
+Because a kernel-mode and a UMDF driver can share the same service name on one system, `--type` selects the intended target explicitly. When `--type` is omitted the command prefers the kernel candidate; if only a UMDF candidate is found it falls back and emits a `[*]` warning on stderr. If neither candidate exists the command exits with code 2.
+
+#### Examples
+
+```text
+# Enable verbose tracing for the BthPS3 kernel driver
+etwutils verbose BthPS3 --enable
+
+# Check the current state of both kernel and UMDF candidates
+etwutils verbose BthPS3 --status
+
+# Disable verbose tracing
+etwutils verbose BthPS3 --disable
+
+# When both a kernel and a UMDF driver share the same name, target explicitly
+etwutils verbose Foo --enable --type umdf
+etwutils verbose Foo --enable --type kernel
+
+# Preview what --enable would do without writing anything
+etwutils verbose BthPS3 --enable --dry-run
+```
+
+> **Note:** After toggling `VerboseOn`, the change only takes effect once the driver restarts or the device is re-enumerated. A future `etwutils` release will add `--restart-devices` to automate this step.
+
 ### `inspect-pdb`
 
 Parse PDB files and report every embedded WPP provider GUID without starting an ETW session.

--- a/tools/Nefarius.Utilities.ETW.CLI/VerboseRegistry.cs
+++ b/tools/Nefarius.Utilities.ETW.CLI/VerboseRegistry.cs
@@ -65,9 +65,22 @@ internal static class VerboseRegistry
 
         if (candidate.Kind == ServiceKind.Kernel)
         {
-            // CreateSubKey creates the Parameters subkey if absent (the parent service key must
-            // exist, which Detect() already confirmed by successfully reading the Type value).
-            target = hklm.CreateSubKey(candidate.TargetKeyPath, writable: true);
+            // Split TargetKeyPath into the parent service key and the "Parameters" child name
+            // so that CreateSubKey only ever creates the leaf ("Parameters") and never
+            // recreates a parent service key that was deleted after detection.
+            int sep = candidate.TargetKeyPath.LastIndexOf('\\');
+            string parentPath = candidate.TargetKeyPath[..sep];
+            string childName  = candidate.TargetKeyPath[(sep + 1)..];
+
+            using RegistryKey? parentKey = hklm.OpenSubKey(parentPath, writable: true);
+            if (parentKey is null)
+            {
+                throw new InvalidOperationException(
+                    $"Service key HKLM\\{parentPath} no longer exists. " +
+                    "The service may have been removed after detection.");
+            }
+
+            target = parentKey.CreateSubKey(childName, writable: true);
         }
         else
         {
@@ -80,8 +93,7 @@ internal static class VerboseRegistry
         if (target is null)
         {
             throw new InvalidOperationException(
-                $"Could not open registry key HKLM\\{candidate.TargetKeyPath}. " +
-                "The key must already exist for UMDF services.");
+                $"Could not open or create registry key HKLM\\{candidate.TargetKeyPath}.");
         }
 
         target.SetValue("VerboseOn", 1, RegistryValueKind.DWord);

--- a/tools/Nefarius.Utilities.ETW.CLI/VerboseRegistry.cs
+++ b/tools/Nefarius.Utilities.ETW.CLI/VerboseRegistry.cs
@@ -1,0 +1,135 @@
+using Microsoft.Win32;
+
+namespace Nefarius.Utilities.ETW.CLI;
+
+internal enum ServiceKind
+{
+    Kernel,
+    Umdf
+}
+
+/// <summary>
+///     A detected driver service candidate with a resolved registry target path.
+/// </summary>
+internal sealed record Candidate(ServiceKind Kind, string TargetKeyPath, int? CurrentValue);
+
+/// <summary>
+///     Result of probing both kernel-mode and UMDF locations for a service name.
+///     Both fields can be non-null simultaneously when a kernel and a UMDF driver share the same service name.
+/// </summary>
+internal sealed record DetectionResult(Candidate? Kernel, Candidate? Umdf);
+
+/// <summary>
+///     Registry helpers for reading and writing the <c>VerboseOn</c> REG_DWORD value that
+///     enables WPP verbose tracing for kernel-mode and UMDF driver services.
+/// </summary>
+internal static class VerboseRegistry
+{
+    // SERVICE_KERNEL_DRIVER = 1, SERVICE_FILE_SYSTEM_DRIVER = 2
+    private const int ServiceKernelDriver     = 0x1;
+    private const int ServiceFilesystemDriver = 0x2;
+
+    private const string ServicesRoot = @"SYSTEM\CurrentControlSet\Services";
+    private const string WudfRoot     = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\WUDF\Services";
+
+    /// <summary>
+    ///     Probes both the kernel-mode services hive and the WUDF hive for <paramref name="serviceName" />.
+    ///     Returns a <see cref="DetectionResult" /> whose <see cref="DetectionResult.Kernel" /> and
+    ///     <see cref="DetectionResult.Umdf" /> fields are set independently; either or both may be
+    ///     <see langword="null" /> when the respective candidate is absent.
+    ///     This method never decides which candidate to use — that decision belongs to the caller.
+    /// </summary>
+    internal static DetectionResult Detect(string serviceName)
+    {
+        Candidate? kernel = ProbeKernel(serviceName);
+        Candidate? umdf   = ProbeUmdf(serviceName);
+        return new DetectionResult(kernel, umdf);
+    }
+
+    /// <summary>
+    ///     Writes <c>VerboseOn = 1</c> (REG_DWORD) at the location described by
+    ///     <paramref name="candidate" />.  For kernel services the <c>Parameters</c> subkey is
+    ///     created on demand when it does not already exist.
+    ///     Throws <see cref="UnauthorizedAccessException" /> when the process lacks write access
+    ///     (i.e. is not elevated); the caller is responsible for translating this into an error message.
+    /// </summary>
+    internal static void Enable(Candidate candidate)
+    {
+        using RegistryKey hklm    = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+        using RegistryKey? target = hklm.CreateSubKey(candidate.TargetKeyPath, writable: true);
+
+        if (target is null)
+        {
+            throw new InvalidOperationException(
+                $"Could not open or create registry key HKLM\\{candidate.TargetKeyPath}.");
+        }
+
+        target.SetValue("VerboseOn", 1, RegistryValueKind.DWord);
+    }
+
+    /// <summary>
+    ///     Deletes the <c>VerboseOn</c> value from the location described by
+    ///     <paramref name="candidate" />, if present.  When the value is already absent this is a
+    ///     silent no-op.  The parent key itself is never deleted.
+    ///     Throws <see cref="UnauthorizedAccessException" /> when the process lacks write access.
+    /// </summary>
+    internal static void Disable(Candidate candidate)
+    {
+        using RegistryKey hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+        using RegistryKey? target = hklm.OpenSubKey(candidate.TargetKeyPath, writable: true);
+
+        // Key absent means VerboseOn cannot be set there — nothing to do.
+        if (target is null) return;
+
+        target.DeleteValue("VerboseOn", throwOnMissingValue: false);
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    private static Candidate? ProbeKernel(string serviceName)
+    {
+        string serviceKeyPath = $@"{ServicesRoot}\{serviceName}";
+
+        using RegistryKey hklm       = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+        using RegistryKey? serviceKey = hklm.OpenSubKey(serviceKeyPath, writable: false);
+
+        if (serviceKey is null) return null;
+
+        object? typeVal = serviceKey.GetValue("Type");
+        if (typeVal is not int type) return null;
+
+        if (type != ServiceKernelDriver && type != ServiceFilesystemDriver) return null;
+
+        // VerboseOn lives in the Parameters subkey.
+        string targetPath = $@"{ServicesRoot}\{serviceName}\Parameters";
+        int?   current    = ReadVerboseOn(hklm, targetPath);
+
+        return new Candidate(ServiceKind.Kernel, targetPath, current);
+    }
+
+    private static Candidate? ProbeUmdf(string serviceName)
+    {
+        string wudfKeyPath = $@"{WudfRoot}\{serviceName}";
+
+        using RegistryKey hklm    = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+        using RegistryKey? wudfKey = hklm.OpenSubKey(wudfKeyPath, writable: false);
+
+        if (wudfKey is null) return null;
+
+        // VerboseOn is stored directly under the WUDF service key.
+        int? current = ReadVerboseOn(hklm, wudfKeyPath);
+
+        return new Candidate(ServiceKind.Umdf, wudfKeyPath, current);
+    }
+
+    private static int? ReadVerboseOn(RegistryKey hklm, string keyPath)
+    {
+        using RegistryKey? key = hklm.OpenSubKey(keyPath, writable: false);
+        if (key is null) return null;
+
+        object? val = key.GetValue("VerboseOn");
+        return val is int i ? i : null;
+    }
+}

--- a/tools/Nefarius.Utilities.ETW.CLI/VerboseRegistry.cs
+++ b/tools/Nefarius.Utilities.ETW.CLI/VerboseRegistry.cs
@@ -48,20 +48,40 @@ internal static class VerboseRegistry
 
     /// <summary>
     ///     Writes <c>VerboseOn = 1</c> (REG_DWORD) at the location described by
-    ///     <paramref name="candidate" />.  For kernel services the <c>Parameters</c> subkey is
-    ///     created on demand when it does not already exist.
+    ///     <paramref name="candidate" />.
+    ///     <list type="bullet">
+    ///       <item>Kernel: the <c>Parameters</c> subkey is created on demand when absent; the parent
+    ///         service key must already exist.</item>
+    ///       <item>UMDF: the WUDF service key must already exist; it is never auto-created so that a
+    ///         stale or mismatched service name cannot synthesise phantom registry entries.</item>
+    ///     </list>
     ///     Throws <see cref="UnauthorizedAccessException" /> when the process lacks write access
     ///     (i.e. is not elevated); the caller is responsible for translating this into an error message.
     /// </summary>
     internal static void Enable(Candidate candidate)
     {
-        using RegistryKey hklm    = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
-        using RegistryKey? target = hklm.CreateSubKey(candidate.TargetKeyPath, writable: true);
+        using RegistryKey hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+        RegistryKey? target;
+
+        if (candidate.Kind == ServiceKind.Kernel)
+        {
+            // CreateSubKey creates the Parameters subkey if absent (the parent service key must
+            // exist, which Detect() already confirmed by successfully reading the Type value).
+            target = hklm.CreateSubKey(candidate.TargetKeyPath, writable: true);
+        }
+        else
+        {
+            // For UMDF the target is the WUDF service key itself; never auto-create it.
+            target = hklm.OpenSubKey(candidate.TargetKeyPath, writable: true);
+        }
+
+        using RegistryKey? _ = target; // ensure Dispose regardless of path
 
         if (target is null)
         {
             throw new InvalidOperationException(
-                $"Could not open or create registry key HKLM\\{candidate.TargetKeyPath}.");
+                $"Could not open registry key HKLM\\{candidate.TargetKeyPath}. " +
+                "The key must already exist for UMDF services.");
         }
 
         target.SetValue("VerboseOn", 1, RegistryValueKind.DWord);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `verbose` command to view, enable, or disable WPP verbose tracing for kernel and UMDF drivers. Supports `--enable`, `--disable`, `--status`, optional `--type` (kernel|umdf), mutual-exclusion validation, and `--dry-run`. `--status` reports combined kernel/UMDF state without making changes; enable/disable prefers kernel unless `--type` forces UMDF.

* **Documentation**
  * Added CLI docs with usage examples and elevation guidance.

* **Chores**
  * Added a new project dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/Nefarius.Utilities.ETW/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->