### PR TITLE
Changed verbose command to verbs

### DIFF
--- a/tools/Nefarius.Utilities.ETW.CLI/Program.cs
+++ b/tools/Nefarius.Utilities.ETW.CLI/Program.cs
@@ -653,23 +653,13 @@ Argument<string> verboseServiceArg = new("service-name")
     Description = "Name of the driver service to target (e.g. BthPS3)."
 };
 
-Option<bool> verboseEnableOpt = new("--enable")
+Argument<string> verboseActionArg = new("action")
 {
     Description =
-        "Set VerboseOn = 1 (REG_DWORD) in the driver service's registry key " +
-        "(Parameters subkey for kernel-mode; service key directly for UMDF)."
-};
-
-Option<bool> verboseDisableOpt = new("--disable")
-{
-    Description =
-        "Delete the VerboseOn value from the driver service's registry key " +
-        "(Parameters subkey for kernel-mode; service key directly for UMDF)."
-};
-
-Option<bool> verboseStatusOpt = new("--status")
-{
-    Description = "Show the current VerboseOn state for the service without making changes."
+        "Action to perform: " +
+        "'enable' writes VerboseOn = 1 (Parameters subkey for kernel-mode; service key directly for UMDF); " +
+        "'disable' deletes the VerboseOn value (no-op when already absent); " +
+        "'status' prints the current VerboseOn state without making changes."
 };
 
 Option<string?> verboseTypeOpt = new("--type")
@@ -688,24 +678,20 @@ Command verbose = new(
     "verbose",
     "Enable or disable WPP verbose tracing for a kernel-mode or UMDF driver service by " +
     "writing the VerboseOn REG_DWORD to the driver's registry key. " +
-    "Requires an elevated (admin) process for --enable and --disable.")
+    "Requires an elevated (admin) process for 'enable' and 'disable'.")
 {
     verboseServiceArg,
-    verboseEnableOpt,
-    verboseDisableOpt,
-    verboseStatusOpt,
+    verboseActionArg,
     verboseTypeOpt,
     verboseDryRunOpt
 };
 
 verbose.SetAction((ParseResult result) =>
 {
-    string serviceName = result.GetValue(verboseServiceArg)!;
-    bool   doEnable    = result.GetValue(verboseEnableOpt);
-    bool   doDisable   = result.GetValue(verboseDisableOpt);
-    bool   doStatus    = result.GetValue(verboseStatusOpt);
-    string? typeRaw    = result.GetValue(verboseTypeOpt);
-    bool   dryRun      = result.GetValue(verboseDryRunOpt);
+    string  serviceName = result.GetValue(verboseServiceArg)!;
+    string  actionRaw   = result.GetValue(verboseActionArg)!;
+    string? typeRaw     = result.GetValue(verboseTypeOpt);
+    bool    dryRun      = result.GetValue(verboseDryRunOpt);
 
     // --- Validate service name ---
     if (string.IsNullOrWhiteSpace(serviceName))
@@ -723,17 +709,15 @@ verbose.SetAction((ParseResult result) =>
         return 2;
     }
 
-    // --- Validate mutually exclusive action flags ---
-    int actionCount = (doEnable ? 1 : 0) + (doDisable ? 1 : 0) + (doStatus ? 1 : 0);
-    if (actionCount == 0)
-    {
-        Console.Error.WriteLine("[!] One of --enable, --disable, or --status is required.");
-        return 2;
-    }
+    // --- Validate action ---
+    bool doEnable = actionRaw.Equals("enable", StringComparison.OrdinalIgnoreCase);
+    bool doDisable = actionRaw.Equals("disable", StringComparison.OrdinalIgnoreCase);
+    bool doStatus  = actionRaw.Equals("status", StringComparison.OrdinalIgnoreCase);
 
-    if (actionCount > 1)
+    if (!doEnable && !doDisable && !doStatus)
     {
-        Console.Error.WriteLine("[!] Only one of --enable, --disable, or --status may be specified at a time.");
+        Console.Error.WriteLine(
+            $"[!] Unknown action '{actionRaw}'. Expected 'enable', 'disable', or 'status'.");
         return 2;
     }
 

--- a/tools/Nefarius.Utilities.ETW.CLI/README.md
+++ b/tools/Nefarius.Utilities.ETW.CLI/README.md
@@ -106,17 +106,14 @@ Enable or disable WPP verbose tracing for a kernel-mode or UMDF driver service b
 > **Admin required.** `--enable` and `--disable` write to `HKEY_LOCAL_MACHINE` and require an elevated process.
 
 ```text
-etwutils verbose <service-name>
-    (--enable | --disable | --status)
-    [--type kernel|umdf]
-    [--dry-run]
+etwutils verbose <service-name> <enable|disable|status> [--type kernel|umdf] [--dry-run]
 ```
 
-| Option | Description |
+| Argument / Option | Description |
 |---|---|
-| `--enable` | Write `VerboseOn = 1` (REG_DWORD) to the service's Parameters key |
-| `--disable` | Delete the `VerboseOn` value (silent no-op when already absent) |
-| `--status` | Print the current state for both kernel and UMDF candidates; no registry writes |
+| `enable` | Write `VerboseOn = 1` (REG_DWORD) to the service's registry key |
+| `disable` | Delete the `VerboseOn` value (silent no-op when already absent) |
+| `status` | Print the current state for both kernel and UMDF candidates; no registry writes |
 | `--type kernel\|umdf` | Target a specific driver kind explicitly (see detection rules below) |
 | `--dry-run` | Print what would be done without touching the registry; exits 0 |
 
@@ -138,23 +135,23 @@ Because a kernel-mode and a UMDF driver can share the same service name on one s
 
 #### Examples
 
-```text
-# Enable verbose tracing for the BthPS3 kernel driver
-etwutils verbose BthPS3 --enable
+    ```text
+    # Enable verbose tracing for the BthPS3 kernel driver
+    etwutils verbose BthPS3 enable
 
-# Check the current state of both kernel and UMDF candidates
-etwutils verbose BthPS3 --status
+    # Check the current state of both kernel and UMDF candidates
+    etwutils verbose BthPS3 status
 
-# Disable verbose tracing
-etwutils verbose BthPS3 --disable
+    # Disable verbose tracing
+    etwutils verbose BthPS3 disable
 
-# When both a kernel and a UMDF driver share the same name, target explicitly
-etwutils verbose Foo --enable --type umdf
-etwutils verbose Foo --enable --type kernel
+    # When both a kernel and a UMDF driver share the same name, target explicitly
+    etwutils verbose Foo enable --type umdf
+    etwutils verbose Foo enable --type kernel
 
-# Preview what --enable would do without writing anything
-etwutils verbose BthPS3 --enable --dry-run
-```
+    # Preview what enable would do without writing anything
+    etwutils verbose BthPS3 enable --dry-run
+    ```
 
 > **Note:** After toggling `VerboseOn`, the change only takes effect once the driver restarts or the device is re-enumerated. A future `etwutils` release will add `--restart-devices` to automate this step.
 

--- a/tools/Nefarius.Utilities.ETW.CLI/README.md
+++ b/tools/Nefarius.Utilities.ETW.CLI/README.md
@@ -103,7 +103,7 @@ etwutils realtime [<provider-guid> ...]
 
 Enable or disable WPP verbose tracing for a kernel-mode or UMDF driver service by writing the `VerboseOn` `REG_DWORD` under the driver's registry parameters key.
 
-> **Admin required.** `--enable` and `--disable` write to `HKEY_LOCAL_MACHINE` and require an elevated process.
+> **Admin required.** The `enable` and `disable` actions write to `HKEY_LOCAL_MACHINE` and require an elevated process.
 
 ```text
 etwutils verbose <service-name> <enable|disable|status> [--type kernel|umdf] [--dry-run]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Changed `verbose` command syntax from boolean flags (`--enable`, `--disable`, `--status`) to a single positional action (`enable`, `disable`, `status`)

* **New Features**
  * Added `--type kernel|umdf` option to target specific service types
  * Added `--dry-run` option for previewing actions without making changes

* **Documentation**
  * Updated command docs and examples to reflect new syntax, behavior, and usage scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/Nefarius.Utilities.ETW/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->