### PR TITLE
Exposed warning about missing format information

### DIFF
--- a/src/Deserializer/CustomParsers/WppTraceEventParser.cs
+++ b/src/Deserializer/CustomParsers/WppTraceEventParser.cs
@@ -83,10 +83,14 @@ internal sealed class WppTraceEventParser : ICustomParser
             nameof(WppEventRecord.ProviderGuid), false, false, 0, null);
     }
 
-    public WppTraceEventParser(DecodingContext decodingContext)
+    private readonly Action<Guid, ushort, uint>? _onFormatMissing;
+
+    public WppTraceEventParser(DecodingContext decodingContext,
+        Action<Guid, ushort, uint>? onFormatMissing = null)
     {
         ArgumentNullException.ThrowIfNull(decodingContext);
         DecodingContext = decodingContext;
+        _onFormatMissing = onFormatMissing;
     }
 
     public DecodingContext DecodingContext { get; init; }
@@ -112,7 +116,7 @@ internal sealed class WppTraceEventParser : ICustomParser
 
         WppEventRecord decodedRecord = new(reader);
         // this does the heavy lifting of retrieving properties with the decoding context 
-        decodedRecord.Decode(DecodingContext);
+        decodedRecord.Decode(DecodingContext, _onFormatMissing);
 
         writer.WriteEventBegin(eventMetadata, runtimeMetadata);
 

--- a/src/Deserializer/Deserializer.cs
+++ b/src/Deserializer/Deserializer.cs
@@ -53,13 +53,14 @@ internal sealed partial class Deserializer<T>
     }
 
     public Deserializer(T writer, Func<Guid, Stream?>? customProviderManifest,
-        DecodingContext? decodingContext = null) : this(writer)
+        DecodingContext? decodingContext = null,
+        Action<Guid, ushort, uint>? onWppFormatMissing = null) : this(writer)
     {
         _customProviderManifest = customProviderManifest;
 
         if (decodingContext is not null)
         {
-            _wppTraceEventParser = new WppTraceEventParser(decodingContext);
+            _wppTraceEventParser = new WppTraceEventParser(decodingContext, onWppFormatMissing);
         }
     }
 

--- a/src/Deserializer/WPP/WppEventRecord.cs
+++ b/src/Deserializer/WPP/WppEventRecord.cs
@@ -76,10 +76,16 @@ internal unsafe partial class WppEventRecord(EventRecordReader eventRecordReader
     ///     Decodes well-known WPP properties from a given <see cref="EVENT_RECORD" />.
     /// </summary>
     /// <param name="decodingContext">The <see cref="DecodingContext" /> to use.</param>
+    /// <param name="onFormatMissing">
+    ///     Optional callback invoked when no <see cref="TMF.TraceMessageFormat" /> is found for this
+    ///     event. Receives the trace GUID, the event id, and the version. Fires before the
+    ///     placeholder <c>FormattedString</c> is written.
+    /// </param>
     /// <exception cref="TdhGetEventInformationException">Failed to get event information.</exception>
     /// <exception cref="TdhGetPropertySizeException">Failed to query property size.</exception>
     /// <exception cref="TdhGetPropertyException">Failed to get property content.</exception>
-    public void Decode(DecodingContext decodingContext)
+    public void Decode(DecodingContext decodingContext,
+        Action<Guid, ushort, uint>? onFormatMissing = null)
     {
         ObjectAccessor? self = ObjectAccessor.Create(this, true);
 
@@ -194,6 +200,8 @@ internal unsafe partial class WppEventRecord(EventRecordReader eventRecordReader
                                 .Append(Version)
                                 .Append(" - No format information found.")
                                 .ToString();
+
+                            onFormatMissing?.Invoke(TraceGuid, GuidTypeNameFormatId, Version);
                         }
 
                         if (value is not null)

--- a/src/EtwJsonConverterOptions.cs
+++ b/src/EtwJsonConverterOptions.cs
@@ -15,6 +15,15 @@ public sealed class EtwJsonConverterOptions
     public Action<string>? ReportError { get; set; }
 
     /// <summary>
+    ///     Invoked whenever a WPP event is decoded but no matching <see cref="Deserializer.WPP.TMF.TraceMessageFormat" />
+    ///     was found in the supplied <see cref="WppDecodingContext" /> (i.e. the event's <c>FormattedString</c> was
+    ///     substituted with the <c>"GUID=... - No format information found."</c> placeholder).
+    ///     Receives the provider trace GUID, the WPP event id, and the version.
+    ///     Fires once per affected event; consumers are expected to deduplicate as needed.
+    /// </summary>
+    public Action<Guid, ushort, uint>? OnWppFormatMissing { get; set; }
+
+    /// <summary>
     ///     Custom manifest provider lookup.
     /// </summary>
     public Func<Guid, Stream?>? CustomProviderManifest { get; set; }

--- a/src/EtwUtil.cs
+++ b/src/EtwUtil.cs
@@ -85,7 +85,8 @@ public static class EtwUtil
         Deserializer<EtwJsonWriter> deserializer = new(
             new EtwJsonWriter(jsonWriter),
             opts.CustomProviderManifest,
-            opts.WppDecodingContext
+            opts.WppDecodingContext,
+            opts.OnWppFormatMissing
         );
 
         int count = list.Count;
@@ -212,7 +213,8 @@ public static class EtwUtil
         Deserializer<EtwJsonWriter> deserializer = new(
             new EtwJsonWriter(jsonWriter),
             opts.CustomProviderManifest,
-            opts.WppDecodingContext
+            opts.WppDecodingContext,
+            opts.OnWppFormatMissing
         );
 
         EVENT_TRACE_LOGFILEW session;
@@ -634,7 +636,8 @@ public static class EtwUtil
         Deserializer<EtwJsonChannelWriter> deserializer = new(
             channelWriter,
             opts.CustomProviderManifest,
-            opts.WppDecodingContext
+            opts.WppDecodingContext,
+            opts.OnWppFormatMissing
         );
 
         string workerName = realtimeSessionName is not null

--- a/tools/Nefarius.Utilities.ETW.CLI/Program.cs
+++ b/tools/Nefarius.Utilities.ETW.CLI/Program.cs
@@ -969,6 +969,8 @@ static async Task<int> RunAsync(
         TryEnableWindowsVt();
     }
 
+    Action<Guid, ushort, uint> missingFormatWarner = CreateMissingFormatWarner();
+
     try
     {
         using EtwRealtimeSession session = EtwRealtimeSession.Create(sessionName, opts =>
@@ -997,7 +999,11 @@ static async Task<int> RunAsync(
 
         await foreach (ReadOnlyMemory<byte> json in EtwUtil.EnumerateRealtimeEventsAsync(
                            sessionName,
-                           o => o.WppDecodingContext = decodingContext,
+                           o =>
+                           {
+                               o.WppDecodingContext  = decodingContext;
+                               o.OnWppFormatMissing  = missingFormatWarner;
+                           },
                            cts.Token))
         {
             // Stop emitting immediately once cancellation is requested so no
@@ -1697,6 +1703,8 @@ static async Task<int> RunParseStdoutAsync(
         ? new StreamWriter(Console.OpenStandardOutput(), new System.Text.UTF8Encoding(false), 65536)
         : null;
 
+    Action<Guid, ushort, uint> missingFormatWarner = CreateMissingFormatWarner();
+
     Console.Error.WriteLine($"[*] Streaming {etlFiles.Count} .etl file(s) to stdout...");
 
     try
@@ -1713,6 +1721,7 @@ static async Task<int> RunParseStdoutAsync(
                            {
                                o.WppDecodingContext    = decodingContext;
                                o.PreserveRawTimestamps = preserveRawTimestamps;
+                               o.OnWppFormatMissing    = missingFormatWarner;
                            },
                            cts.Token))
         {
@@ -1813,6 +1822,9 @@ static async Task<int> RunParsePerFileAsync(
 
     bool anyFailed = false;
 
+    // One warner per command run so each provider GUID is reported at most once across all ETL files.
+    Action<Guid, ushort, uint> missingFormatWarner = CreateMissingFormatWarner();
+
     foreach (string etl in etlFiles)
     {
         if (cancellationToken.IsCancellationRequested) break;
@@ -1844,6 +1856,7 @@ static async Task<int> RunParsePerFileAsync(
                                    {
                                        o.WppDecodingContext    = decodingContext;
                                        o.PreserveRawTimestamps = preserveRawTimestamps;
+                                       o.OnWppFormatMissing    = missingFormatWarner;
                                    },
                                    cancellationToken))
                 {
@@ -1864,6 +1877,7 @@ static async Task<int> RunParsePerFileAsync(
                                    {
                                        o.WppDecodingContext    = decodingContext;
                                        o.PreserveRawTimestamps = preserveRawTimestamps;
+                                       o.OnWppFormatMissing    = missingFormatWarner;
                                    },
                                    cancellationToken))
                 {
@@ -1909,6 +1923,30 @@ static bool ResolveColor(string colorOpt)
     if (!string.IsNullOrEmpty(noColor)) return false;
     if (Console.IsOutputRedirected) return false;
     return true;
+}
+
+/// <summary>
+///     Returns a callback suitable for <see cref="EtwJsonConverterOptions.OnWppFormatMissing" /> that
+///     prints a single <c>[!]</c> warning to <c>stderr</c> the first time each provider GUID is seen
+///     without format information.  The deduplication is per-instance so callers should create one
+///     warner per command invocation and share it across all option-lambdas in that run.
+/// </summary>
+static Action<Guid, ushort, uint> CreateMissingFormatWarner()
+{
+    HashSet<Guid> warned = [];
+    return (guid, _, _) =>
+    {
+        lock (warned)
+        {
+            if (!warned.Add(guid)) return;
+            Console.Error.WriteLine(
+                $"[!] No WPP format information found for provider {{{guid}}}. " +
+                "This usually means the loaded PDB does not match the binary that produced the trace " +
+                "(wrong PDB age/GUID). Affected events will appear as " +
+                "'GUID=... - No format information found.' and may not match --filter expressions " +
+                "targeting Message, FunctionName, Function, or Level.");
+        }
+    };
 }
 
 /// <summary>

--- a/tools/Nefarius.Utilities.ETW.CLI/README.md
+++ b/tools/Nefarius.Utilities.ETW.CLI/README.md
@@ -60,7 +60,7 @@ When `--symbols-search`, `--symbol-server`, or `--symbol-cache` is supplied (or 
 2. **Search paths** — first case-insensitive filename match in `--symbols-search` directories.
 3. **Symbol server** — `GET <url>/<pdbname>/<GUID><AGE>/<pdbname>`; downloaded atomically into the cache.
 
-Unresolved PDBs log a `[!]` warning and are non-fatal; affected WPP events fall back to a `GUID=...` placeholder.
+Unresolved PDBs log a `[!]` warning and are non-fatal; affected WPP events fall back to a `GUID=...` placeholder. In addition, each distinct provider GUID that triggers the placeholder also emits a one-time `[!]` warning to `stderr` at decode time, so symbol mismatches are surfaced immediately even when piping output through `--filter`.
 
 ##### Default cache directory
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced extensible callback mechanism to enable custom handling of missing WPP provider format information during event deserialization.
  * CLI now displays warnings when WPP symbol format metadata is unavailable, improving diagnostics for unresolved provider information.

* **Documentation**
  * Enhanced README with comprehensive details on warning messages, deduplication behavior, and event formatting fallbacks for missing symbols.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/Nefarius.Utilities.ETW/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->