### PR TITLE
Fixed crash in `TdhGetPropertySize`

### DIFF
--- a/src/Deserializer/WPP/WppEventRecord.cs
+++ b/src/Deserializer/WPP/WppEventRecord.cs
@@ -130,6 +130,13 @@ internal unsafe partial class WppEventRecord(EventRecordReader eventRecordReader
                 // we expect 20 WPP properties, but this dynamic approach is safer
                 for (int propertyIndex = 0; propertyIndex < traceEventInfo->PropertyCount; propertyIndex++)
                 {
+                    // Reset UserData to the original payload start before every TDH call.
+                    // SubstituteFunctionParameters (called for FormattedString) advances UserData
+                    // through ItemReader.Readers, but UserDataLength is never adjusted. Without this
+                    // reset, TdhGetPropertySize on subsequent properties reads past the buffer end,
+                    // causing an intermittent 0xC0000005 access violation.
+                    eventRecordReader.Reset();
+
                     EVENT_PROPERTY_INFO propertyInfo = traceEventInfo->EventPropertyInfoArray[propertyIndex];
                     _TDH_IN_TYPE propertyType = (_TDH_IN_TYPE)propertyInfo.Anonymous1.customSchemaType.InType;
                     string propertyName = new((char*)((byte*)traceEventInfo + propertyInfo.NameOffset));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an intermittent access violation that could occur during event record deserialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/Nefarius.Utilities.ETW/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->