### PR TITLE
Added logic to rewrite the `Provider`/`GuidName` to the friendly name extracted from `TMC`

### DIFF
--- a/src/Deserializer/CustomParsers/WppTraceEventParser.cs
+++ b/src/Deserializer/CustomParsers/WppTraceEventParser.cs
@@ -84,13 +84,16 @@ internal sealed class WppTraceEventParser : ICustomParser
     }
 
     private readonly Action<Guid, ushort, uint>? _onFormatMissing;
+    private readonly bool _rewriteProviderName;
 
     public WppTraceEventParser(DecodingContext decodingContext,
-        Action<Guid, ushort, uint>? onFormatMissing = null)
+        Action<Guid, ushort, uint>? onFormatMissing = null,
+        bool rewriteProviderName = false)
     {
         ArgumentNullException.ThrowIfNull(decodingContext);
         DecodingContext = decodingContext;
         _onFormatMissing = onFormatMissing;
+        _rewriteProviderName = rewriteProviderName;
     }
 
     public DecodingContext DecodingContext { get; init; }
@@ -116,7 +119,7 @@ internal sealed class WppTraceEventParser : ICustomParser
 
         WppEventRecord decodedRecord = new(reader);
         // this does the heavy lifting of retrieving properties with the decoding context 
-        decodedRecord.Decode(DecodingContext, _onFormatMissing);
+        decodedRecord.Decode(DecodingContext, _onFormatMissing, _rewriteProviderName);
 
         writer.WriteEventBegin(eventMetadata, runtimeMetadata);
 

--- a/src/Deserializer/Deserializer.cs
+++ b/src/Deserializer/Deserializer.cs
@@ -54,13 +54,14 @@ internal sealed partial class Deserializer<T>
 
     public Deserializer(T writer, Func<Guid, Stream?>? customProviderManifest,
         DecodingContext? decodingContext = null,
-        Action<Guid, ushort, uint>? onWppFormatMissing = null) : this(writer)
+        Action<Guid, ushort, uint>? onWppFormatMissing = null,
+        bool rewriteWppProviderName = false) : this(writer)
     {
         _customProviderManifest = customProviderManifest;
 
         if (decodingContext is not null)
         {
-            _wppTraceEventParser = new WppTraceEventParser(decodingContext, onWppFormatMissing);
+            _wppTraceEventParser = new WppTraceEventParser(decodingContext, onWppFormatMissing, rewriteWppProviderName);
         }
     }
 

--- a/src/Deserializer/WPP/DecodingContext.cs
+++ b/src/Deserializer/WPP/DecodingContext.cs
@@ -18,6 +18,12 @@ public sealed class DecodingContext
     private readonly IReadOnlyCollection<Guid> _providerGuids;
 
     /// <summary>
+    ///     Maps (MessageGuid, Id) -> friendly control name for PDB sources that declare exactly one
+    ///     unambiguous <c>WPP_DEFINE_CONTROL_GUID</c>. Built lazily on first use.
+    /// </summary>
+    private readonly IReadOnlyDictionary<TraceMessageFormatLookupKey, string> _providerNameOverrides;
+
+    /// <summary>
     ///     New decoding context instance.
     /// </summary>
     /// <param name="decodingTypes">One or more <see cref="DecodingContextType" />s to look up decoding information in.</param>
@@ -39,6 +45,40 @@ public sealed class DecodingContext
             .SelectMany(t => t.ProviderGuids)
             .Distinct()
             .ToArray();
+
+        // Build the provider-name override map. Only PDB sources with exactly one non-empty control name
+        // contribute entries; zero or multiple controls are ambiguous and are skipped silently.
+        Dictionary<TraceMessageFormatLookupKey, string> overrides = [];
+
+        foreach (DecodingContextType t in _decodingTypes)
+        {
+            if (t is not PdbFileDecodingContextType pdb)
+            {
+                continue;
+            }
+
+            IReadOnlyCollection<WppTraceControl> controls = pdb.WppTraceControls;
+
+            if (controls.Count != 1)
+            {
+                continue;
+            }
+
+            string controlName = controls.Single().Name;
+
+            if (string.IsNullOrEmpty(controlName))
+            {
+                continue;
+            }
+
+            foreach (TraceMessageFormat fmt in pdb.TraceMessageFormats)
+            {
+                TraceMessageFormatLookupKey key = new(fmt.MessageGuid, fmt.Id);
+                overrides.TryAdd(key, controlName);
+            }
+        }
+
+        _providerNameOverrides = overrides.AsReadOnly();
     }
 
     /// <summary>
@@ -59,6 +99,18 @@ public sealed class DecodingContext
         TraceMessageFormatLookupKey key = new(messageGuid.Value, id);
 
         return _lookup.GetValueOrDefault(key);
+    }
+
+    /// <summary>
+    ///     Returns the friendly TMC control name (e.g. <c>DsHidMiniTraceGuid</c>) for the given message format,
+    ///     or <see langword="null" /> if no unambiguous override is available (TMF-only context, or a PDB with
+    ///     zero / multiple control GUIDs).  Used by <see cref="WppEventRecord" /> when provider-name rewriting
+    ///     is enabled.
+    /// </summary>
+    internal string? GetWppProviderNameOverride(TraceMessageFormat format)
+    {
+        TraceMessageFormatLookupKey key = new(format.MessageGuid, format.Id);
+        return _providerNameOverrides.GetValueOrDefault(key);
     }
 
     /// <summary>

--- a/src/Deserializer/WPP/DecodingContext.cs
+++ b/src/Deserializer/WPP/DecodingContext.cs
@@ -19,7 +19,7 @@ public sealed class DecodingContext
 
     /// <summary>
     ///     Maps (MessageGuid, Id) -> friendly control name for PDB sources that declare exactly one
-    ///     unambiguous <c>WPP_DEFINE_CONTROL_GUID</c>. Built lazily on first use.
+    ///     unambiguous <c>WPP_DEFINE_CONTROL_GUID</c>. Populated eagerly in the constructor.
     /// </summary>
     private readonly IReadOnlyDictionary<TraceMessageFormatLookupKey, string> _providerNameOverrides;
 
@@ -66,7 +66,7 @@ public sealed class DecodingContext
 
             string controlName = controls.Single().Name;
 
-            if (string.IsNullOrEmpty(controlName))
+            if (string.IsNullOrWhiteSpace(controlName))
             {
                 continue;
             }

--- a/src/Deserializer/WPP/WppEventRecord.cs
+++ b/src/Deserializer/WPP/WppEventRecord.cs
@@ -81,11 +81,17 @@ internal unsafe partial class WppEventRecord(EventRecordReader eventRecordReader
     ///     event. Receives the trace GUID, the event id, and the version. Fires before the
     ///     placeholder <c>FormattedString</c> is written.
     /// </param>
+    /// <param name="rewriteProviderName">
+    ///     When <see langword="true" />, the <c>GuidName</c> field is overridden with the friendly
+    ///     TMC control name from <see cref="DecodingContext.GetWppProviderNameOverride" /> if
+    ///     available. Falls back to <c>format.Provider</c> when no override is found.
+    /// </param>
     /// <exception cref="TdhGetEventInformationException">Failed to get event information.</exception>
     /// <exception cref="TdhGetPropertySizeException">Failed to query property size.</exception>
     /// <exception cref="TdhGetPropertyException">Failed to get property content.</exception>
     public void Decode(DecodingContext decodingContext,
-        Action<Guid, ushort, uint>? onFormatMissing = null)
+        Action<Guid, ushort, uint>? onFormatMissing = null,
+        bool rewriteProviderName = false)
     {
         ObjectAccessor? self = ObjectAccessor.Create(this, true);
 
@@ -177,7 +183,9 @@ internal unsafe partial class WppEventRecord(EventRecordReader eventRecordReader
                         {
                             value = propertyName switch
                             {
-                                nameof(GuidName) => format.Provider,
+                                nameof(GuidName) => (rewriteProviderName
+                                    ? decodingContext.GetWppProviderNameOverride(format)
+                                    : null) ?? format.Provider,
                                 nameof(GuidTypeName) => format.Opcode,
                                 nameof(FlagsName) => format.Flags,
                                 nameof(LevelName) => format.Level,

--- a/src/EtwJsonConverterOptions.cs
+++ b/src/EtwJsonConverterOptions.cs
@@ -41,6 +41,25 @@ public sealed class EtwJsonConverterOptions
     public DecodingContext? WppDecodingContext { get; set; }
 
     /// <summary>
+    ///     When <see langword="true" />, the <c>GuidName</c> / <c>Provider</c> field in decoded WPP events is
+    ///     overridden with the friendly name declared in the <c>TMC:</c> <c>WPP_DEFINE_CONTROL_GUID</c> annotation
+    ///     (e.g. <c>DsHidMiniTraceGuid</c>) instead of the raw TMF module token (e.g. <c>sys</c>).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The override is resolved on a per-PDB basis: if a PDB declares exactly one control GUID whose
+    ///         name is non-empty, every message format that originated from that PDB is mapped to that name.
+    ///         PDBs with zero or more than one control GUID are skipped (ambiguous mapping) and the original
+    ///         <c>format.Provider</c> value is kept unchanged — so the fallback is always silent and safe.
+    ///     </para>
+    ///     <para>
+    ///         Has no effect when <see cref="WppDecodingContext" /> is not set or was built from TMF files only.
+    ///     </para>
+    ///     <para>Default is <see langword="false" /> (existing output is unchanged).</para>
+    /// </remarks>
+    public bool RewriteWppProviderName { get; set; }
+
+    /// <summary>
     ///     If set, <c>PROCESS_TRACE_MODE_RAW_TIMESTAMP</c> will be applied when processing the trace record.
     /// </summary>
     /// <remarks>

--- a/src/EtwUtil.cs
+++ b/src/EtwUtil.cs
@@ -86,7 +86,8 @@ public static class EtwUtil
             new EtwJsonWriter(jsonWriter),
             opts.CustomProviderManifest,
             opts.WppDecodingContext,
-            opts.OnWppFormatMissing
+            opts.OnWppFormatMissing,
+            opts.RewriteWppProviderName
         );
 
         int count = list.Count;
@@ -214,7 +215,8 @@ public static class EtwUtil
             new EtwJsonWriter(jsonWriter),
             opts.CustomProviderManifest,
             opts.WppDecodingContext,
-            opts.OnWppFormatMissing
+            opts.OnWppFormatMissing,
+            opts.RewriteWppProviderName
         );
 
         EVENT_TRACE_LOGFILEW session;
@@ -637,7 +639,8 @@ public static class EtwUtil
             channelWriter,
             opts.CustomProviderManifest,
             opts.WppDecodingContext,
-            opts.OnWppFormatMissing
+            opts.OnWppFormatMissing,
+            opts.RewriteWppProviderName
         );
 
         string workerName = realtimeSessionName is not null

--- a/tests/Shared.cs
+++ b/tests/Shared.cs
@@ -114,6 +114,59 @@ public static class Shared
         return Encoding.UTF8.GetString(ms.ToArray());
     }
 
+    /// <summary>
+    ///     Decodes <c>BthPS3_0.etl</c> with both PDB files and the provider-name rewrite enabled.
+    /// </summary>
+    public static string BthPs3EtlTraceDecodeToStringWithRewrite()
+    {
+        const string etwFilePath = @".\traces\BthPS3_0.etl";
+
+        JsonWriterOptions options = new() { Indented = true };
+
+        using MemoryStream ms = new();
+        using Utf8JsonWriter jsonWriter = new(ms, options);
+        DecodingContext decodingContext = new(PdbFileDecodingContextType.CreateFrom(
+            @".\symbols\BthPS3.pdb",
+            @".\symbols\BthPS3PSM.pdb"
+        ));
+
+        if (!EtwUtil.ConvertToJson(jsonWriter, [etwFilePath], converterOptions =>
+            {
+                converterOptions.WppDecodingContext = decodingContext;
+                converterOptions.RewriteWppProviderName = true;
+            }))
+        {
+            throw new InvalidOperationException("BthPS3 ETL decode with rewrite failed.");
+        }
+
+        return Encoding.UTF8.GetString(ms.ToArray());
+    }
+
+    /// <summary>
+    ///     Decodes <c>DsHidMini.etl</c> with <c>DsHidMini.pdb</c> and the provider-name rewrite enabled.
+    /// </summary>
+    public static string DsHidMiniEtlTraceDecodeToStringWithRewrite()
+    {
+        const string etwFilePath = @".\traces\DsHidMini.etl";
+
+        JsonWriterOptions options = new() { Indented = true };
+
+        using MemoryStream ms = new();
+        using Utf8JsonWriter jsonWriter = new(ms, options);
+        DecodingContext decodingContext = new(new PdbFileDecodingContextType(@".\symbols\DsHidMini.pdb"));
+
+        if (!EtwUtil.ConvertToJson(jsonWriter, [etwFilePath], converterOptions =>
+            {
+                converterOptions.WppDecodingContext = decodingContext;
+                converterOptions.RewriteWppProviderName = true;
+            }))
+        {
+            throw new InvalidOperationException("DsHidMini ETL decode with rewrite failed.");
+        }
+
+        return Encoding.UTF8.GetString(ms.ToArray());
+    }
+
     // Kept for backward compatibility with benchmarks.
     public static bool BthPs3EtlTraceDecoding()
     {

--- a/tests/Snapshots/BthPS3_0_rewrite_summary.verified.txt
+++ b/tests/Snapshots/BthPS3_0_rewrite_summary.verified.txt
@@ -1,0 +1,32 @@
+{
+  TotalEventCount: 663,
+  WppEventCount: 658,
+  DecodedWppCount: 658,
+  UniqueEventNames: [
+    MSNT_SystemTrace/EventTrace/BuildInfo,
+    MSNT_SystemTrace/EventTrace/DbgIdRSDS,
+    MSNT_SystemTrace/EventTrace/Header,
+    MSNT_SystemTrace/EventTrace/PartitionInfoExtensionV2,
+    WPP
+  ],
+  SampleDecodedEvents: [
+    {
+      Provider: BthPS3PSMTraceGuid,
+      Function: BthPS3PSMEvtIoInternalDeviceControl,
+      Level: TRACE_LEVEL_VERBOSE,
+      FormattedString: [BthPS3PSMEvtIoInternalDeviceControl]>> Bulk IN transfer (PipeHandle: 0xFFFF95820BE02120)
+    },
+    {
+      Provider: BthPS3PSMTraceGuid,
+      Function: BthPS3PSMEvtIoInternalDeviceControl,
+      Level: TRACE_LEVEL_VERBOSE,
+      FormattedString: [BthPS3PSMEvtIoInternalDeviceControl]>> Bulk IN transfer (PipeHandle: 0xFFFF95820BE02120)
+    },
+    {
+      Provider: BthPS3PSMTraceGuid,
+      Function: BthPS3PSMEvtIoInternalDeviceControl,
+      Level: TRACE_LEVEL_VERBOSE,
+      FormattedString: [BthPS3PSMEvtIoInternalDeviceControl]>> Bulk IN transfer (PipeHandle: 0xFFFF95820BE02120)
+    }
+  ]
+}

--- a/tests/Snapshots/DsHidMini_rewrite_summary.verified.txt
+++ b/tests/Snapshots/DsHidMini_rewrite_summary.verified.txt
@@ -1,0 +1,32 @@
+{
+  TotalEventCount: 68183,
+  WppEventCount: 68179,
+  DecodedWppCount: 68179,
+  UniqueEventNames: [
+    MSNT_SystemTrace/EventTrace/BuildInfo,
+    MSNT_SystemTrace/EventTrace/DbgIdRSDS,
+    MSNT_SystemTrace/EventTrace/Header,
+    MSNT_SystemTrace/EventTrace/PartitionInfoExtensionV2,
+    WPP
+  ],
+  SampleDecodedEvents: [
+    {
+      Provider: DsHidMiniTraceGuid,
+      Function: DriverEntry,
+      Level: TRACE_LEVEL_INFORMATION,
+      FormattedString: [DriverEntry]DriverEntry Entry
+    },
+    {
+      Provider: DsHidMiniTraceGuid,
+      Function: InitIPC,
+      Level: TRACE_LEVEL_VERBOSE,
+      FormattedString: [InitIPC] --> Entry
+    },
+    {
+      Provider: DsHidMiniTraceGuid,
+      Function: InitIPC,
+      Level: TRACE_LEVEL_ERROR,
+      FormattedString: [InitIPC] ERROR:WdfRegistryQueryULong failed with status STATUS_NO_SUCH_FILE (0xC000000F)
+    }
+  ]
+}

--- a/tests/UnitTestDecodingContext.cs
+++ b/tests/UnitTestDecodingContext.cs
@@ -331,4 +331,80 @@ public class DecodingContextTests
 
         Assert.That(context.ProviderGuids, Does.Not.Contain(KnownGuid));
     }
+
+    // -----------------------------------------------------------------------
+    // DecodingContext.GetWppProviderNameOverride  (internal, via InternalsVisibleTo)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Category("Parse")]
+    public void GetWppProviderNameOverride_ReturnsBthPS3TraceGuid_ForKnownBthPS3Format()
+    {
+        // BthPS3.pdb declares exactly one control (BthPS3TraceGuid), so every format
+        // derived from that PDB should resolve to the friendly control name.
+        DecodingContext context =
+            new(PdbFileDecodingContextType.CreateFrom(@".\symbols\BthPS3.pdb"));
+
+        TraceMessageFormat? format = context.GetTraceMessageFormatFor(KnownGuid, KnownId);
+
+        Assert.That(format, Is.Not.Null, "Precondition: known format must resolve.");
+        string? name = context.GetWppProviderNameOverride(format!);
+        Assert.That(name, Is.EqualTo("BthPS3TraceGuid"));
+    }
+
+    [Test]
+    [Category("Parse")]
+    public void GetWppProviderNameOverride_ReturnsBthPS3PsmTraceGuid_ForKnownBthPS3PsmFormat()
+    {
+        // Build a combined context — BthPS3.pdb and BthPS3PSM.pdb each declare exactly
+        // one control, so the override map should contain entries for both.
+        DecodingContext context = new(PdbFileDecodingContextType.CreateFrom(
+            @".\symbols\BthPS3.pdb",
+            @".\symbols\BthPS3PSM.pdb"
+        ));
+
+        // KnownGuid/KnownId belongs to BthPS3.pdb, so the override must be BthPS3TraceGuid.
+        TraceMessageFormat? format = context.GetTraceMessageFormatFor(KnownGuid, KnownId);
+        Assert.That(format, Is.Not.Null, "Precondition: BthPS3 format must resolve.");
+        Assert.That(context.GetWppProviderNameOverride(format!), Is.EqualTo("BthPS3TraceGuid"));
+    }
+
+    [Test]
+    [Category("Parse")]
+    public void GetWppProviderNameOverride_ReturnsNull_ForTmfOnlyContext()
+    {
+        // TMF files carry no TMC: annotations, so no override entries can be built.
+        IList<DecodingContextType> tmfTypes =
+            TmfFilesDirectoryDecodingContextType.CreateFrom(@".\symbols");
+        DecodingContext context = new(tmfTypes);
+
+        TraceMessageFormat? format = context.GetTraceMessageFormatFor(KnownGuid, KnownId);
+        Assert.That(format, Is.Not.Null, "Precondition: TMF format must resolve.");
+        Assert.That(context.GetWppProviderNameOverride(format!), Is.Null,
+            "TMF-only context must produce no override (graceful fallback).");
+    }
+
+    [Test]
+    [Category("Unit")]
+    public void GetWppProviderNameOverride_ReturnsNull_ForUnknownFormat()
+    {
+        DecodingContext context =
+            new(PdbFileDecodingContextType.CreateFrom(@".\symbols\BthPS3.pdb"));
+
+        // Fabricate a format that does not exist in BthPS3.pdb.
+        TraceMessageFormat unknown = new()
+        {
+            MessageGuid = Guid.NewGuid(),
+            Id = 999,
+            Provider = "phantom",
+            FileName = "phantom.c",
+            Opcode = "op",
+            MessageFormat = "%0",
+            Level = "TRACE_LEVEL_VERBOSE",
+            Flags = "TRACE_DRIVER",
+            Function = "PhantomFn"
+        };
+
+        Assert.That(context.GetWppProviderNameOverride(unknown), Is.Null);
+    }
 }

--- a/tests/UnitTestDecodingContext.cs
+++ b/tests/UnitTestDecodingContext.cs
@@ -354,19 +354,28 @@ public class DecodingContextTests
 
     [Test]
     [Category("Parse")]
-    public void GetWppProviderNameOverride_ReturnsBthPS3PsmTraceGuid_ForKnownBthPS3PsmFormat()
+    public void GetWppProviderNameOverride_ReturnsBothControlNames_ForCombinedContext()
     {
+        // BthPS3PSM.pdb: MessageGuid ca66b9c0-..., Id 13 (Device_c104) — verified from cvdump.
+        Guid psmMessageGuid = Guid.Parse("ca66b9c0-97d7-3776-3daf-3296492866aa");
+        const int psmId = 13;
+
         // Build a combined context — BthPS3.pdb and BthPS3PSM.pdb each declare exactly
-        // one control, so the override map should contain entries for both.
+        // one control, so the override map must contain entries for both independently.
         DecodingContext context = new(PdbFileDecodingContextType.CreateFrom(
             @".\symbols\BthPS3.pdb",
             @".\symbols\BthPS3PSM.pdb"
         ));
 
-        // KnownGuid/KnownId belongs to BthPS3.pdb, so the override must be BthPS3TraceGuid.
-        TraceMessageFormat? format = context.GetTraceMessageFormatFor(KnownGuid, KnownId);
-        Assert.That(format, Is.Not.Null, "Precondition: BthPS3 format must resolve.");
-        Assert.That(context.GetWppProviderNameOverride(format!), Is.EqualTo("BthPS3TraceGuid"));
+        // KnownGuid/KnownId belongs to BthPS3.pdb.
+        TraceMessageFormat? bthPs3Format = context.GetTraceMessageFormatFor(KnownGuid, KnownId);
+        Assert.That(bthPs3Format, Is.Not.Null, "Precondition: BthPS3 format must resolve.");
+        Assert.That(context.GetWppProviderNameOverride(bthPs3Format!), Is.EqualTo("BthPS3TraceGuid"));
+
+        // psmMessageGuid/psmId belongs to BthPS3PSM.pdb.
+        TraceMessageFormat? psmFormat = context.GetTraceMessageFormatFor(psmMessageGuid, psmId);
+        Assert.That(psmFormat, Is.Not.Null, "Precondition: BthPS3PSM format must resolve.");
+        Assert.That(context.GetWppProviderNameOverride(psmFormat!), Is.EqualTo("BthPS3PSMTraceGuid"));
     }
 
     [Test]

--- a/tests/UnitTestSnapshotTests.cs
+++ b/tests/UnitTestSnapshotTests.cs
@@ -42,6 +42,24 @@ public class SnapshotTests
             .UseFileName("DsHidMini_summary");
     }
 
+    [Test]
+    public Task BthPs3EtlTrace_WithProviderRewrite_SnapshotMatches()
+    {
+        object summary = BuildSummary(Shared.BthPs3EtlTraceDecodeToStringWithRewrite(), sampleCount: 3);
+        return Verifier.Verify(summary)
+            .UseDirectory("Snapshots")
+            .UseFileName("BthPS3_0_rewrite_summary");
+    }
+
+    [Test]
+    public Task DsHidMiniEtlTrace_WithProviderRewrite_SnapshotMatches()
+    {
+        object summary = BuildSummary(Shared.DsHidMiniEtlTraceDecodeToStringWithRewrite(), sampleCount: 3);
+        return Verifier.Verify(summary)
+            .UseDirectory("Snapshots")
+            .UseFileName("DsHidMini_rewrite_summary");
+    }
+
     // -----------------------------------------------------------------------
 
     /// <summary>

--- a/tools/Nefarius.Utilities.ETW.CLI/PlainOutput.cs
+++ b/tools/Nefarius.Utilities.ETW.CLI/PlainOutput.cs
@@ -296,7 +296,16 @@ internal static class PlainOutput
     ///     Returns <see langword="null" /> when the JSON cannot be parsed or does not contain
     ///     the expected structure.
     /// </summary>
-    public static PlainEvent? Decode(ReadOnlyMemory<byte> jsonBytes)
+    /// <param name="jsonBytes">Raw NDJSON event buffer.</param>
+    /// <param name="providerOverride">
+    ///     Optional <c>ControlGuid → friendly name</c> map built from PDB <c>TMC:</c> annotations.
+    ///     When non-null and an entry is found for the WPP event's <c>Properties[0].TraceGuid</c>,
+    ///     the <see cref="PlainEvent.Provider" /> field is set to the mapped name instead of the
+    ///     raw <c>GuidName</c> value.  A <see langword="null" /> map or a missing/empty entry
+    ///     falls back to the original value gracefully.
+    /// </param>
+    public static PlainEvent? Decode(ReadOnlyMemory<byte> jsonBytes,
+        IReadOnlyDictionary<Guid, string>? providerOverride = null)
     {
         JsonDocument doc;
         try
@@ -387,6 +396,19 @@ internal static class PlainOutput
                 if (p.TryGetProperty("SubComponentName",out JsonElement sc)) subComponent = sc.GetString() ?? string.Empty;
                 if (p.TryGetProperty("FlagsName",       out JsonElement fl)) flags        = fl.GetString() ?? string.Empty;
                 if (p.TryGetProperty("CpuNumber",       out JsonElement wppCpu)) wppCpu.TryGetInt32(out cpu);
+
+                // Apply provider-name override from PDB TMC: control-GUID annotations when available.
+                // Falls back to the GuidName read above when the map is null, the GUID is absent/unparseable,
+                // or the entry is not found / has an empty name.
+                if (providerOverride is not null &&
+                    p.TryGetProperty("TraceGuid", out JsonElement tgEl) &&
+                    tgEl.ValueKind == JsonValueKind.String &&
+                    Guid.TryParse(tgEl.GetString(), out Guid traceGuid) &&
+                    providerOverride.TryGetValue(traceGuid, out string? mappedName) &&
+                    !string.IsNullOrEmpty(mappedName))
+                {
+                    provider = mappedName;
+                }
 
                 levelNumber = DeriveLevelNumber(levelName);
             }

--- a/tools/Nefarius.Utilities.ETW.CLI/Program.cs
+++ b/tools/Nefarius.Utilities.ETW.CLI/Program.cs
@@ -103,6 +103,15 @@ Option<string?> realtimeFilterOpt = new("--filter")
         "Example: Provider != \"Foo\" && Message.StartsWith(\"Bar\"). Ignored when --format is not plain."
 };
 
+Option<bool> realtimeKeepOriginalProviderOpt = new("--keep-original-provider")
+{
+    Description =
+        "Keep the raw WPP Provider/GuidName value emitted by the decoder instead of rewriting it to the " +
+        "friendly control-GUID name (e.g. BthPS3TraceGuid) recovered from PDB TMC: annotations. " +
+        "By default the rewrite is active when PDB symbols containing TMC: records are loaded; " +
+        "it is a silent no-op when no such records are found."
+};
+
 // ---------------------------------------------------------------------------
 // 'realtime' subcommand
 // ---------------------------------------------------------------------------
@@ -122,7 +131,8 @@ Command realtime = new(
     colorOpt,
     realtimeColumnsOpt,
     realtimeHeaderOpt,
-    realtimeFilterOpt
+    realtimeFilterOpt,
+    realtimeKeepOriginalProviderOpt
 };
 
 realtime.SetAction(async (ParseResult result, CancellationToken cancellationToken) =>
@@ -140,6 +150,7 @@ realtime.SetAction(async (ParseResult result, CancellationToken cancellationToke
     string? columnsRaw = result.GetValue(realtimeColumnsOpt);
     bool emitHeader = result.GetValue(realtimeHeaderOpt);
     string? filterExpr = result.GetValue(realtimeFilterOpt);
+    bool keepOriginalProvider = result.GetValue(realtimeKeepOriginalProviderOpt);
 
     if (!formatRaw.Equals("ndjson", StringComparison.OrdinalIgnoreCase) &&
         !formatRaw.Equals("plain", StringComparison.OrdinalIgnoreCase))
@@ -223,6 +234,7 @@ realtime.SetAction(async (ParseResult result, CancellationToken cancellationToke
         columns,
         emitHeader,
         filter,
+        keepOriginalProvider,
         cancellationToken);
 });
 
@@ -473,6 +485,15 @@ Option<string?> parseFilterOpt = new("--filter")
         "Example: Provider != \"Foo\" && Message.StartsWith(\"Bar\"). Ignored when --format is not plain."
 };
 
+Option<bool> parseKeepOriginalProviderOpt = new("--keep-original-provider")
+{
+    Description =
+        "Keep the raw WPP Provider/GuidName value emitted by the decoder instead of rewriting it to the " +
+        "friendly control-GUID name (e.g. BthPS3TraceGuid) recovered from PDB TMC: annotations. " +
+        "By default the rewrite is active when PDB symbols containing TMC: records are loaded; " +
+        "it is a silent no-op when no such records are found."
+};
+
 // ---------------------------------------------------------------------------
 // 'parse' subcommand
 // ---------------------------------------------------------------------------
@@ -494,7 +515,8 @@ Command parse = new(
     parsePreserveRawTimestampsOpt,
     parseColumnsOpt,
     parseHeaderOpt,
-    parseFilterOpt
+    parseFilterOpt,
+    parseKeepOriginalProviderOpt
 };
 
 parse.SetAction(async (ParseResult result, CancellationToken cancellationToken) =>
@@ -511,6 +533,7 @@ parse.SetAction(async (ParseResult result, CancellationToken cancellationToken) 
     string?  columnsRaw        = result.GetValue(parseColumnsOpt);
     bool     emitHeader        = result.GetValue(parseHeaderOpt);
     string?  filterExpr        = result.GetValue(parseFilterOpt);
+    bool     keepOriginalProvider = result.GetValue(parseKeepOriginalProviderOpt);
 
     // --- Validate format / color ---
     if (!formatRaw.Equals("ndjson", StringComparison.OrdinalIgnoreCase) &&
@@ -633,16 +656,20 @@ parse.SetAction(async (ParseResult result, CancellationToken cancellationToken) 
     List<DecodingContextType> allTypes = [..explicitTypes, ..autoTypes];
     DecodingContext? decodingContext = allTypes.Count > 0 ? new DecodingContext(allTypes) : null;
 
+    // Build the provider-name rewrite map from PDB TMC: annotations.
+    IReadOnlyDictionary<Guid, string>? providerNameMap =
+        BuildProviderNameMap(allTypes, keepOriginalProvider);
+
     if (outDir is not null)
     {
         return await RunParsePerFileAsync(
             etlFiles, outDir, decodingContext, usePlain, preserveRaw,
-            columns, emitHeader, filter, cancellationToken);
+            columns, emitHeader, filter, providerNameMap, cancellationToken);
     }
 
     return await RunParseStdoutAsync(
         etlFiles, decodingContext, usePlain, useColor, preserveRaw,
-        columns, emitHeader, filter, cancellationToken);
+        columns, emitHeader, filter, providerNameMap, cancellationToken);
 });
 
 // ---------------------------------------------------------------------------
@@ -863,6 +890,36 @@ return await root.Parse(args).InvokeAsync();
 // Implementation
 // ---------------------------------------------------------------------------
 
+/// <summary>
+///     Builds the provider-name rewrite map from the loaded decoding contexts and the
+///     <c>--keep-original-provider</c> flag.
+///     Returns <see langword="null" /> when the flag is set or when no TMC records are available
+///     (in both cases the callers skip the rewrite entirely, preserving existing behaviour).
+///     When the flag is NOT set but the map ends up empty (e.g. only TMF sources were loaded),
+///     a single informational note is written to stderr and <see langword="null" /> is returned.
+/// </summary>
+static IReadOnlyDictionary<Guid, string>? BuildProviderNameMap(
+    IEnumerable<DecodingContextType> types,
+    bool keepOriginalProvider)
+{
+    if (keepOriginalProvider)
+    {
+        return null;
+    }
+
+    Dictionary<Guid, string> map = WppProviderRewriter.BuildNameMap(types);
+
+    if (map.Count == 0)
+    {
+        Console.Error.WriteLine(
+            "[*] WPP provider name rewrite: no TMC control-GUID names found in the loaded symbols; " +
+            "using original Provider values. Pass --keep-original-provider to suppress this notice.");
+        return null;
+    }
+
+    return map;
+}
+
 static ulong ParseKeywordMask(string raw)
 {
     ReadOnlySpan<char> s = raw.AsSpan().Trim();
@@ -888,10 +945,15 @@ static async Task<int> RunAsync(
     IReadOnlyList<PlainOutput.ColumnSpec> columns,
     bool emitHeader,
     Func<PlainOutput.PlainEvent, bool>? filter,
+    bool keepOriginalProvider,
     CancellationToken cancellationToken)
 {
     // Resolve --symbols paths into a DecodingContext and the raw context list.
     (DecodingContext? decodingContext, List<DecodingContextType> contextTypes) = ResolveSymbols(symbolPaths);
+
+    // Build provider-name rewrite map from PDB TMC: annotations.
+    IReadOnlyDictionary<Guid, string>? providerNameMap =
+        BuildProviderNameMap(contextTypes, keepOriginalProvider);
 
     // Determine the final provider list: explicit args take precedence; fall back to WPP control
     // GUIDs extracted from TMC: annotations in the PDB files.
@@ -1012,14 +1074,17 @@ static async Task<int> RunAsync(
 
             if (usePlain)
             {
-                await WritePlainLineAsync(json, plainOut!, useColor, columns, filter, cts.Token);
+                await WritePlainLineAsync(json, plainOut!, useColor, columns, filter, providerNameMap, cts.Token);
             }
             else
             {
                 // Each buffer is a self-contained JSON object; append a newline for NDJSON,
                 // then flush immediately so events appear in realtime rather than waiting
                 // for the buffer to fill.
-                await ndjsonOut!.WriteAsync(json, cts.Token);
+                ReadOnlyMemory<byte> outJson = providerNameMap is not null
+                    ? WppProviderRewriter.Rewrite(json, providerNameMap)
+                    : json;
+                await ndjsonOut!.WriteAsync(outJson, cts.Token);
                 ndjsonOut.WriteByte((byte)'\n');
                 await ndjsonOut.FlushAsync(cts.Token);
             }
@@ -1679,6 +1744,7 @@ static async Task<int> RunParseStdoutAsync(
     IReadOnlyList<PlainOutput.ColumnSpec> columns,
     bool emitHeader,
     Func<PlainOutput.PlainEvent, bool>? filter,
+    IReadOnlyDictionary<Guid, string>? providerNameMap,
     CancellationToken cancellationToken)
 {
     using CancellationTokenSource cts =
@@ -1729,11 +1795,14 @@ static async Task<int> RunParseStdoutAsync(
 
             if (usePlain)
             {
-                await WritePlainLineAsync(json, plainOut!, useColor, columns, filter, cts.Token);
+                await WritePlainLineAsync(json, plainOut!, useColor, columns, filter, providerNameMap, cts.Token);
             }
             else
             {
-                await ndjsonOut!.WriteAsync(json, cts.Token);
+                ReadOnlyMemory<byte> outJson = providerNameMap is not null
+                    ? WppProviderRewriter.Rewrite(json, providerNameMap)
+                    : json;
+                await ndjsonOut!.WriteAsync(outJson, cts.Token);
                 ndjsonOut.WriteByte((byte)'\n');
                 await ndjsonOut.FlushAsync(cts.Token);
             }
@@ -1781,6 +1850,7 @@ static async Task<int> RunParsePerFileAsync(
     IReadOnlyList<PlainOutput.ColumnSpec> columns,
     bool emitHeader,
     Func<PlainOutput.PlainEvent, bool>? filter,
+    IReadOnlyDictionary<Guid, string>? providerNameMap,
     CancellationToken cancellationToken)
 {
     string ext = usePlain ? ".tsv" : ".ndjson";
@@ -1861,7 +1931,7 @@ static async Task<int> RunParsePerFileAsync(
                                    cancellationToken))
                 {
                     bool written = await WritePlainLineAsync(
-                        json, writer, false, columns, filter, cancellationToken, flush: false);
+                        json, writer, false, columns, filter, providerNameMap, cancellationToken, flush: false);
                     if (written) eventCount++;
                 }
 
@@ -1881,7 +1951,10 @@ static async Task<int> RunParsePerFileAsync(
                                    },
                                    cancellationToken))
                 {
-                    await buffered.WriteAsync(json, cancellationToken);
+                    ReadOnlyMemory<byte> outJson = providerNameMap is not null
+                        ? WppProviderRewriter.Rewrite(json, providerNameMap)
+                        : json;
+                    await buffered.WriteAsync(outJson, cancellationToken);
                     buffered.WriteByte((byte)'\n');
                     eventCount++;
                 }
@@ -1982,13 +2055,14 @@ static async Task<bool> WritePlainLineAsync(
     bool useColor,
     IReadOnlyList<PlainOutput.ColumnSpec> columns,
     Func<PlainOutput.PlainEvent, bool>? filter,
+    IReadOnlyDictionary<Guid, string>? providerNameMap,
     CancellationToken cancellationToken,
     bool flush = true)
 {
     // Decode failures and filter evaluation exceptions are propagated as fatal errors so the
     // caller's outer try-catch logs them and returns exit code 1. A filter returning false
     // is a normal, non-fatal drop and still returns false here.
-    PlainOutput.PlainEvent evt = PlainOutput.Decode(json)
+    PlainOutput.PlainEvent evt = PlainOutput.Decode(json, providerNameMap)
         ?? throw new InvalidOperationException("Could not parse event JSON.");
 
     if (filter is not null && !filter(evt))

--- a/tools/Nefarius.Utilities.ETW.CLI/README.md
+++ b/tools/Nefarius.Utilities.ETW.CLI/README.md
@@ -68,7 +68,7 @@ Unresolved PDBs log a `[!]` warning and are non-fatal; affected WPP events fall 
 By default, when PDB files containing `WPP_DEFINE_CONTROL_GUID` declarations are loaded, the `Provider`/`GuidName` field in every WPP event is rewritten from the raw folder-derived token (e.g. `obj\amd64`) to the friendly name declared in the source (`BthPS3TraceGuid`). The rewrite is best-effort:
 
 - Events whose control GUID is not found in any loaded PDB are left unchanged.
-- TMF-only sources do not carry control-GUID names, so the rewrite is a silent no-op in that case.
+- TMF-only sources do not carry control-GUID names, so no rewrite occurs, but a one-time informational notice is emitted to stderr to make the situation visible.
 
 Pass `--keep-original-provider` to suppress the rewrite and use the original decoder value as-is.
 

--- a/tools/Nefarius.Utilities.ETW.CLI/README.md
+++ b/tools/Nefarius.Utilities.ETW.CLI/README.md
@@ -41,6 +41,7 @@ etwutils parse <etl-path> [<etl-path> ...]
     [--columns          <list>]        # plain only: comma-separated column tokens; default Timestamp,Provider,Level,Message
     [--header]                         # plain only: emit a TSV header line first
     [--filter           <expression>]  # plain only: DynamicExpresso predicate to drop events
+    [--keep-original-provider]         # keep raw WPP GuidName instead of rewriting to TMC: friendly name
 ```
 
 `<etl-path>` accepts individual `.etl` files, directories (top-level `*.etl` enumeration), and glob patterns (e.g. `C:\Traces\*.etl`). Multiple paths are accepted and deduplicated.
@@ -61,6 +62,15 @@ When `--symbols-search`, `--symbol-server`, or `--symbol-cache` is supplied (or 
 3. **Symbol server** — `GET <url>/<pdbname>/<GUID><AGE>/<pdbname>`; downloaded atomically into the cache.
 
 Unresolved PDBs log a `[!]` warning and are non-fatal; affected WPP events fall back to a `GUID=...` placeholder. In addition, each distinct provider GUID that triggers the placeholder also emits a one-time `[!]` warning to `stderr` at decode time, so symbol mismatches are surfaced immediately even when piping output through `--filter`.
+
+#### WPP provider name rewrite
+
+By default, when PDB files containing `WPP_DEFINE_CONTROL_GUID` declarations are loaded, the `Provider`/`GuidName` field in every WPP event is rewritten from the raw folder-derived token (e.g. `obj\amd64`) to the friendly name declared in the source (`BthPS3TraceGuid`). The rewrite is best-effort:
+
+- Events whose control GUID is not found in any loaded PDB are left unchanged.
+- TMF-only sources do not carry control-GUID names, so the rewrite is a silent no-op in that case.
+
+Pass `--keep-original-provider` to suppress the rewrite and use the original decoder value as-is.
 
 ##### Default cache directory
 
@@ -98,12 +108,15 @@ etwutils realtime [<provider-guid> ...]
     [--columns <list>]                 # plain only: comma-separated column tokens; default Timestamp,Provider,Level,Message
     [--header]                         # plain only: emit a TSV header line first
     [--filter <expression>]            # plain only: DynamicExpresso predicate to drop events
+    [--keep-original-provider]         # keep raw WPP GuidName instead of rewriting to TMC: friendly name
 ```
 
 `provider-guid` is **optional**. When omitted, the tool reads the `WPP_DEFINE_CONTROL_GUID` declarations embedded in the PDB files passed to `--symbols` and uses those as the provider list. Explicit GUIDs always take precedence; PDB-derived GUIDs are not added on top of explicit ones.
 
 > [!NOTE]  
 > Auto-derivation requires **PDB files**. TMF files do not contain the WPP control GUID (they only hold per-call-site message format data). If `--symbols` points to a directory or glob that contains only TMF files, you must also supply `provider-guid` explicitly.
+
+The provider name rewrite described under `parse` applies here too. Pass `--keep-original-provider` to disable it.
 
 ### `verbose`
 

--- a/tools/Nefarius.Utilities.ETW.CLI/WppProviderRewriter.cs
+++ b/tools/Nefarius.Utilities.ETW.CLI/WppProviderRewriter.cs
@@ -1,0 +1,180 @@
+using System.Buffers;
+using System.Text.Json;
+
+using Nefarius.Utilities.ETW.Deserializer.WPP;
+
+namespace Nefarius.Utilities.ETW.CLI;
+
+/// <summary>
+///     Rewrites the <c>GuidName</c> property of WPP event buffers using the friendly control-GUID name
+///     recovered from PDB <c>TMC:</c> annotations, providing a more meaningful provider label than the
+///     folder-derived token the WPP decoder normally emits.
+/// </summary>
+internal static class WppProviderRewriter
+{
+    /// <summary>
+    ///     Builds a <c>ControlGuid → friendly name</c> lookup from the loaded decoding contexts.
+    ///     Only <see cref="PdbFileDecodingContextType" /> sources carry <c>TMC:</c> control records;
+    ///     TMF-only sources contribute nothing and are silently skipped.
+    ///     Entries whose <see cref="Deserializer.WPP.TMF.WppTraceControl.Name" /> is null or empty are
+    ///     also skipped so a real value is never replaced by an empty string.
+    /// </summary>
+    /// <returns>
+    ///     A dictionary of GUIDs to names. Empty when no TMC information is available.
+    /// </returns>
+    public static Dictionary<Guid, string> BuildNameMap(IEnumerable<DecodingContextType> types)
+    {
+        Dictionary<Guid, string> map = new();
+
+        foreach (DecodingContextType type in types)
+        {
+            if (type is not PdbFileDecodingContextType pdb)
+            {
+                continue;
+            }
+
+            foreach (Deserializer.WPP.TMF.WppTraceControl ctrl in pdb.WppTraceControls)
+            {
+                if (string.IsNullOrEmpty(ctrl.Name))
+                {
+                    continue;
+                }
+
+                // First entry wins on duplicate GUIDs across multiple PDB files.
+                map.TryAdd(ctrl.ControlGuid, ctrl.Name);
+            }
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    ///     Rewrites the <c>GuidName</c> value inside a single WPP NDJSON event buffer using the
+    ///     supplied provider-name map.  Returns the original buffer unchanged (zero-copy) in every
+    ///     graceful-fallback case:
+    ///     <list type="bullet">
+    ///         <item>The event is not a WPP event (<c>Event.Name != "WPP"</c>).</item>
+    ///         <item><c>Properties[0].TraceGuid</c> is absent or cannot be parsed.</item>
+    ///         <item>The GUID is not present in <paramref name="map" />.</item>
+    ///         <item>The mapped name is null/empty.</item>
+    ///         <item>The mapped name is identical to the existing <c>GuidName</c> value.</item>
+    ///         <item>The JSON cannot be parsed.</item>
+    ///     </list>
+    /// </summary>
+    public static ReadOnlyMemory<byte> Rewrite(
+        ReadOnlyMemory<byte> json,
+        IReadOnlyDictionary<Guid, string> map)
+    {
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            return json;
+        }
+
+        using (doc)
+        {
+            JsonElement root = doc.RootElement;
+
+            if (!root.TryGetProperty("Event", out JsonElement evt))
+            {
+                return json;
+            }
+
+            if (!evt.TryGetProperty("Name", out JsonElement nameEl) ||
+                nameEl.GetString() != "WPP")
+            {
+                return json;
+            }
+
+            if (!evt.TryGetProperty("Properties", out JsonElement propsArr) ||
+                propsArr.ValueKind != JsonValueKind.Array ||
+                propsArr.GetArrayLength() == 0)
+            {
+                return json;
+            }
+
+            JsonElement props0 = propsArr[0];
+
+            // Resolve the control GUID from TraceGuid.
+            if (!props0.TryGetProperty("TraceGuid", out JsonElement traceGuidEl) ||
+                traceGuidEl.ValueKind != JsonValueKind.String)
+            {
+                return json;
+            }
+
+            if (!Guid.TryParse(traceGuidEl.GetString(), out Guid traceGuid))
+            {
+                return json;
+            }
+
+            if (!map.TryGetValue(traceGuid, out string? newName) ||
+                string.IsNullOrEmpty(newName))
+            {
+                return json;
+            }
+
+            // Read the existing GuidName; if it already matches, skip re-emission.
+            if (props0.TryGetProperty("GuidName", out JsonElement existingGn) &&
+                existingGn.GetString() == newName)
+            {
+                return json;
+            }
+
+            // Re-emit the full buffer substituting only GuidName inside Properties[0].
+            ArrayBufferWriter<byte> bufferWriter = new(json.Length + 64);
+            using Utf8JsonWriter writer = new(bufferWriter, new JsonWriterOptions { SkipValidation = true });
+
+            // Root object
+            writer.WriteStartObject();
+
+            // "Event": { ... }
+            writer.WritePropertyName("Event");
+            writer.WriteStartObject();
+
+            foreach (JsonProperty evtProp in evt.EnumerateObject())
+            {
+                if (evtProp.Name != "Properties")
+                {
+                    evtProp.WriteTo(writer);
+                    continue;
+                }
+
+                writer.WritePropertyName("Properties");
+                writer.WriteStartArray();
+
+                int arrIdx = 0;
+                foreach (JsonElement elem in propsArr.EnumerateArray())
+                {
+                    writer.WriteStartObject();
+
+                    foreach (JsonProperty p in elem.EnumerateObject())
+                    {
+                        if (arrIdx == 0 && p.Name == "GuidName")
+                        {
+                            writer.WriteString("GuidName", newName);
+                        }
+                        else
+                        {
+                            p.WriteTo(writer);
+                        }
+                    }
+
+                    writer.WriteEndObject();
+                    arrIdx++;
+                }
+
+                writer.WriteEndArray();
+            }
+
+            writer.WriteEndObject(); // Event
+            writer.WriteEndObject(); // root
+
+            writer.Flush();
+            return bufferWriter.WrittenMemory;
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional WPP provider-name rewriting: provider IDs are replaced with friendly names when available; a CLI flag preserves original names. Rewrite is applied to realtime, parse, plain-mode and NDJSON outputs.

* **Documentation**
  * CLI docs updated to document the new flag, default rewrite behavior, and cases where rewrites are skipped.

* **Tests**
  * Added unit and snapshot tests validating provider-name rewrite behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/Nefarius.Utilities.ETW/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->