### PR TITLE
Added session enumeration support and better error messages

### DIFF
--- a/src/Etw.cs
+++ b/src/Etw.cs
@@ -178,4 +178,15 @@ internal static class Etw
     [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
     [SuppressUnmanagedCodeSecurity]
     internal static extern int CloseTrace([In] ULONGLONG TraceHandle);
+
+    /// <summary>
+    ///     Retrieves the properties and statistics for all running ETW trace sessions.
+    ///     Returns a Win32 error code; does not set the thread-local error (SetLastError=false).
+    /// </summary>
+    [DllImport("advapi32.dll", EntryPoint = "QueryAllTracesW", CharSet = CharSet.Unicode, SetLastError = false)]
+    [SuppressUnmanagedCodeSecurity]
+    internal static extern unsafe uint QueryAllTraces(
+        EVENT_TRACE_PROPERTIES** PropertyArray,
+        uint PropertyArrayCount,
+        out uint LoggerCount);
 }

--- a/src/EtwUtil.cs
+++ b/src/EtwUtil.cs
@@ -469,8 +469,8 @@ public static class EtwUtil
     /// </returns>
     /// <remarks>
     ///     The Windows default maximum is 64 concurrent sessions.  When the registry key
-    ///     <c>EtwMaxLoggers</c> raises the limit above 64, this method retries once with
-    ///     capacity 256 before giving up.
+    ///     <c>EtwMaxLoggers</c> raises the limit above 64, this method retries first with
+    ///     capacity 128 and then with capacity 256 before giving up.
     /// </remarks>
     /// <exception cref="Win32Exception">
     ///     <c>QueryAllTracesW</c> returned a non-zero, non-<c>ERROR_MORE_DATA</c> error code, or
@@ -482,7 +482,7 @@ public static class EtwUtil
         // ETW session names are limited to 1 024 characters including the null terminator.
         const int MaxNameChars = 1024;
 
-        // Try 64 first (system default); retry with 256 if QueryAllTracesW reports more sessions.
+        // Try 64 first (system default); retry with 128 then 256 if QueryAllTracesW reports more sessions.
         for (int capacity = 64; capacity <= 256; capacity *= 2)
         {
             unsafe

--- a/src/EtwUtil.cs
+++ b/src/EtwUtil.cs
@@ -1,4 +1,5 @@
 ﻿using System.Buffers;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -464,13 +465,17 @@ public static class EtwUtil
     /// </summary>
     /// <returns>
     ///     A read-only list of session names in the order reported by <c>QueryAllTracesW</c>.
-    ///     Returns an empty list on failure.
+    ///     An empty list means the system has no active trace sessions.
     /// </returns>
     /// <remarks>
     ///     The Windows default maximum is 64 concurrent sessions.  When the registry key
     ///     <c>EtwMaxLoggers</c> raises the limit above 64, this method retries once with
     ///     capacity 256 before giving up.
     /// </remarks>
+    /// <exception cref="Win32Exception">
+    ///     <c>QueryAllTracesW</c> returned a non-zero, non-<c>ERROR_MORE_DATA</c> error code, or
+    ///     the system reports more than 256 concurrent sessions and the buffer cannot be grown further.
+    /// </exception>
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
     public static IReadOnlyList<string> EnumerateSessionNames()
     {
@@ -502,11 +507,11 @@ public static class EtwUtil
 
                     uint error = Etw.QueryAllTraces(ptrArray, (uint)capacity, out uint loggerCount);
 
-                    // ERROR_MORE_DATA (234) means more sessions exist than we allocated for;
-                    // we still process what was filled in and will retry the outer loop.
+                    // Any error other than ERROR_MORE_DATA (234) is a real API failure.
                     if (error != 0 && error != 234u)
                     {
-                        return [];
+                        throw new Win32Exception((int)error,
+                            $"QueryAllTracesW failed with Win32 error 0x{error:X8}.");
                     }
 
                     uint toRead = Math.Min(loggerCount, (uint)capacity);
@@ -534,7 +539,11 @@ public static class EtwUtil
             }
         }
 
-        return [];
+        // Reached only when QueryAllTracesW still returns ERROR_MORE_DATA after 256 slots —
+        // an extraordinary situation (>256 concurrent ETW sessions).
+        throw new Win32Exception(234,
+            "QueryAllTracesW: the system reports more than 256 concurrent ETW sessions; " +
+            "cannot enumerate all of them.");
     }
 
     // -----------------------------------------------------------------------

--- a/src/EtwUtil.cs
+++ b/src/EtwUtil.cs
@@ -459,6 +459,84 @@ public static class EtwUtil
         }
     }
 
+    /// <summary>
+    ///     Returns the names of all currently running ETW trace sessions.
+    /// </summary>
+    /// <returns>
+    ///     A read-only list of session names in the order reported by <c>QueryAllTracesW</c>.
+    ///     Returns an empty list on failure.
+    /// </returns>
+    /// <remarks>
+    ///     The Windows default maximum is 64 concurrent sessions.  When the registry key
+    ///     <c>EtwMaxLoggers</c> raises the limit above 64, this method retries once with
+    ///     capacity 256 before giving up.
+    /// </remarks>
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public static IReadOnlyList<string> EnumerateSessionNames()
+    {
+        // ETW session names are limited to 1 024 characters including the null terminator.
+        const int MaxNameChars = 1024;
+
+        // Try 64 first (system default); retry with 256 if QueryAllTracesW reports more sessions.
+        for (int capacity = 64; capacity <= 256; capacity *= 2)
+        {
+            unsafe
+            {
+                int propsSize = Marshal.SizeOf<EVENT_TRACE_PROPERTIES>();
+                int nameBytes = (MaxNameChars + 1) * sizeof(char);
+                int slotSize  = propsSize + nameBytes;
+
+                // Allocate the property blocks and the pointer array in native heap.
+                byte* block = (byte*)NativeMemory.AllocZeroed((nuint)(capacity * slotSize));
+                EVENT_TRACE_PROPERTIES** ptrArray =
+                    (EVENT_TRACE_PROPERTIES**)NativeMemory.AllocZeroed((nuint)(capacity * sizeof(void*)));
+                try
+                {
+                    for (int i = 0; i < capacity; i++)
+                    {
+                        EVENT_TRACE_PROPERTIES* slot = (EVENT_TRACE_PROPERTIES*)(block + i * slotSize);
+                        slot->Wnode.BufferSize = (uint)slotSize;
+                        slot->LoggerNameOffset = (uint)propsSize;
+                        ptrArray[i]            = slot;
+                    }
+
+                    uint error = Etw.QueryAllTraces(ptrArray, (uint)capacity, out uint loggerCount);
+
+                    // ERROR_MORE_DATA (234) means more sessions exist than we allocated for;
+                    // we still process what was filled in and will retry the outer loop.
+                    if (error != 0 && error != 234u)
+                    {
+                        return [];
+                    }
+
+                    uint toRead = Math.Min(loggerCount, (uint)capacity);
+                    List<string> names = new((int)toRead);
+                    for (uint i = 0; i < toRead; i++)
+                    {
+                        EVENT_TRACE_PROPERTIES* slot = ptrArray[i];
+                        char* namePtr = (char*)((byte*)slot + slot->LoggerNameOffset);
+                        names.Add(new string(namePtr));
+                    }
+
+                    if (error == 234u && loggerCount > (uint)capacity)
+                    {
+                        // Outer loop will retry with doubled capacity.
+                        continue;
+                    }
+
+                    return names;
+                }
+                finally
+                {
+                    NativeMemory.Free(ptrArray);
+                    NativeMemory.Free(block);
+                }
+            }
+        }
+
+        return [];
+    }
+
     // -----------------------------------------------------------------------
     // Private streaming infrastructure
     // -----------------------------------------------------------------------

--- a/src/Exceptions/EtwEnableTraceException.cs
+++ b/src/Exceptions/EtwEnableTraceException.cs
@@ -26,6 +26,14 @@ public sealed class EtwEnableTraceException : Win32Exception
                 $"Cannot modify provider {{{providerGuid}}} on session '{sessionName}': provider not registered " +
                 "on this system. The provider GUID may be incorrect.",
 
+            WIN32_ERROR.ERROR_NO_SYSTEM_RESOURCES =>
+                $"Cannot modify provider {{{providerGuid}}} on session '{sessionName}': the provider is already " +
+                "enabled in the maximum number of concurrent trace sessions. Modern (manifest-based / TraceLogging) " +
+                "providers allow up to 8 sessions; legacy WPP/MOF providers allow only 1. " +
+                "This is usually caused by leftover sessions from previous runs that were killed before they could " +
+                "stop cleanly. Run 'logman query -ets' to list them and 'logman stop <name> -ets' to remove " +
+                "each one, or use 'etwutils sessions clean' if available.",
+
             _ => $"Cannot modify provider {{{providerGuid}}} on session '{sessionName}': " +
                  $"EnableTraceEx2 failed with Win32 error 0x{(uint)error:X8}."
         };

--- a/tools/Nefarius.Utilities.ETW.CLI/Program.cs
+++ b/tools/Nefarius.Utilities.ETW.CLI/Program.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.Diagnostics;
 using System.Globalization;
 using System.Net.Http;
 using System.Reflection;
@@ -6,6 +7,7 @@ using System.Text.Json;
 
 using Nefarius.Utilities.ETW;
 using Nefarius.Utilities.ETW.CLI;
+using Nefarius.Utilities.ETW.Exceptions;
 using Nefarius.Utilities.ETW.Deserializer.WPP;
 using Nefarius.Utilities.ETW.Deserializer.WPP.TMF;
 
@@ -872,6 +874,161 @@ verbose.SetAction((ParseResult result) =>
 });
 
 // ---------------------------------------------------------------------------
+// 'sessions' subcommand – arguments and options
+// ---------------------------------------------------------------------------
+Argument<string> sessionsActionArg = new("action")
+{
+    Description =
+        "Action to perform: " +
+        "'list' prints all running ETW sessions and annotates NefariusEtwCli-<pid> sessions as alive or dead; " +
+        "'clean' stops NefariusEtwCli-<pid> sessions whose owning process is no longer running."
+};
+
+Option<bool> sessionsAllOpt = new("--all")
+{
+    Description =
+        "For 'clean': also stop sessions whose owning process is still running. " +
+        "Warning: this may interrupt another active etwutils realtime instance."
+};
+
+Option<string> sessionsPrefixOpt = new("--prefix")
+{
+    Description = "Session name prefix to target. Default: NefariusEtwCli-.",
+    DefaultValueFactory = _ => "NefariusEtwCli-"
+};
+
+Option<bool> sessionsDryRunOpt = new("--dry-run")
+{
+    Description = "Print what would be done without stopping any sessions. Exits with code 0."
+};
+
+Command sessions = new(
+    "sessions",
+    "List or clean up running ETW sessions created by etwutils. " +
+    "Useful for removing leftover NefariusEtwCli-<pid> sessions after an abrupt termination. " +
+    "'clean' requires an elevated (administrator) process.")
+{
+    sessionsActionArg,
+    sessionsAllOpt,
+    sessionsPrefixOpt,
+    sessionsDryRunOpt
+};
+
+sessions.SetAction((ParseResult result) =>
+{
+    string actionRaw = result.GetValue(sessionsActionArg)!;
+    bool   doAll     = result.GetValue(sessionsAllOpt);
+    string prefix    = result.GetValue(sessionsPrefixOpt)!;
+    bool   dryRun    = result.GetValue(sessionsDryRunOpt);
+
+    bool doList  = actionRaw.Equals("list",  StringComparison.OrdinalIgnoreCase);
+    bool doClean = actionRaw.Equals("clean", StringComparison.OrdinalIgnoreCase);
+
+    if (!doList && !doClean)
+    {
+        Console.Error.WriteLine(
+            $"[!] Unknown action '{actionRaw}'. Expected 'list' or 'clean'.");
+        return 2;
+    }
+
+    IReadOnlyList<string> allSessions;
+    try
+    {
+        allSessions = EtwUtil.EnumerateSessionNames();
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine(
+            $"[!] Failed to enumerate ETW sessions: {ex.GetType().Name}: {ex.Message}");
+        return 1;
+    }
+
+    if (doList)
+    {
+        Console.Error.WriteLine($"[*] {allSessions.Count} running ETW session(s):");
+        foreach (string name in allSessions)
+        {
+            if (name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
+                TryParsePidSuffix(name, prefix, out int pid))
+            {
+                bool alive = IsProcessAlive(pid);
+                Console.WriteLine($"  {name}  [{(alive ? $"alive pid={pid}" : $"dead  pid={pid}")}]");
+            }
+            else
+            {
+                Console.WriteLine($"  {name}");
+            }
+        }
+
+        return 0;
+    }
+
+    // doClean
+    IEnumerable<string> targets = allSessions
+        .Where(n => n.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                    && TryParsePidSuffix(n, prefix, out int _));
+
+    List<string> toStop = [];
+    foreach (string name in targets)
+    {
+        TryParsePidSuffix(name, prefix, out int pid);
+        bool alive = IsProcessAlive(pid);
+
+        if (alive && !doAll)
+        {
+            Console.Error.WriteLine(
+                $"[*] Skipping '{name}' — process {pid} is still running " +
+                "(pass --all to force-stop live sessions).");
+            continue;
+        }
+
+        toStop.Add(name);
+    }
+
+    if (toStop.Count == 0)
+    {
+        Console.Error.WriteLine("[*] No sessions to clean up.");
+        return 0;
+    }
+
+    int stopped = 0;
+    int failed  = 0;
+    foreach (string name in toStop)
+    {
+        TryParsePidSuffix(name, prefix, out int pid);
+        bool alive = IsProcessAlive(pid);
+        string status = alive ? $"alive pid={pid}" : $"dead pid={pid}";
+
+        if (dryRun)
+        {
+            Console.Error.WriteLine($"[*] Dry run — would stop: {name}  [{status}]");
+            continue;
+        }
+
+        try
+        {
+            EtwUtil.StopOrphanSession(name);
+            Console.Error.WriteLine($"[*] Stopped: {name}  [{status}]");
+            stopped++;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(
+                $"[!] Failed to stop '{name}': {ex.GetType().Name}: {ex.Message}");
+            failed++;
+        }
+    }
+
+    if (!dryRun)
+    {
+        Console.Error.WriteLine(
+            $"[*] Done — stopped {stopped} session(s)" + (failed > 0 ? $", {failed} failed." : "."));
+    }
+
+    return failed > 0 ? 1 : 0;
+});
+
+// ---------------------------------------------------------------------------
 // Root command
 // ---------------------------------------------------------------------------
 RootCommand root = new("etwutils — ETW event decoder and offline trace parser. Stream realtime events or decode .etl files as NDJSON on stdout.")
@@ -879,7 +1036,8 @@ RootCommand root = new("etwutils — ETW event decoder and offline trace parser.
     realtime,
     inspectPdb,
     parse,
-    verbose
+    verbose,
+    sessions
 };
 
 return await root.Parse(args).InvokeAsync();
@@ -1091,6 +1249,17 @@ static async Task<int> RunAsync(
     catch (Exception ex)
     {
         Console.Error.WriteLine($"[!] Fatal error: {ex.GetType().Name}: {ex.Message}");
+
+        // ERROR_NO_SYSTEM_RESOURCES (0x5AA) means the provider is already enabled in the
+        // maximum number of concurrent sessions, usually due to orphaned NefariusEtwCli-<pid>
+        // sessions from previous killed runs.
+        if (ex is EtwEnableTraceException { NativeErrorCode: 0x5AA })
+        {
+            Console.Error.WriteLine(
+                "[!] Tip: leftover sessions from previous killed runs may be holding this provider. " +
+                "Run 'etwutils sessions list' to inspect and 'etwutils sessions clean' to remove dead sessions.");
+        }
+
         return 1;
     }
     finally
@@ -2063,6 +2232,47 @@ static async Task<bool> WritePlainLineAsync(
     if (flush)
         await writer.FlushAsync(cancellationToken);
     return true;
+}
+
+// ---------------------------------------------------------------------------
+// Sessions helpers
+// ---------------------------------------------------------------------------
+
+/// <summary>
+///     Attempts to parse the integer PID from the suffix of <paramref name="sessionName" />
+///     after stripping <paramref name="prefix" />.
+///     Returns <see langword="true" /> and sets <paramref name="pid" /> on success.
+/// </summary>
+static bool TryParsePidSuffix(string sessionName, string prefix, out int pid)
+{
+    pid = -1;
+    if (!sessionName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        return false;
+
+    string suffix = sessionName[prefix.Length..];
+    return int.TryParse(suffix, out pid) && pid > 0;
+}
+
+/// <summary>
+///     Returns <see langword="true" /> when a process with <paramref name="pid" /> currently exists.
+/// </summary>
+static bool IsProcessAlive(int pid)
+{
+    try
+    {
+        using Process proc = Process.GetProcessById(pid);
+        return !proc.HasExited;
+    }
+    catch (ArgumentException)
+    {
+        // Process does not exist.
+        return false;
+    }
+    catch
+    {
+        // Any other error (access denied, etc.) — assume alive to avoid accidental kills.
+        return true;
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/Nefarius.Utilities.ETW.CLI/README.md
+++ b/tools/Nefarius.Utilities.ETW.CLI/README.md
@@ -176,6 +176,49 @@ Because a kernel-mode and a UMDF driver can share the same service name on one s
 > [!NOTE]  
 > After toggling `VerboseOn`, the change only takes effect once the driver restarts or the device is re-enumerated. A future `etwutils` release will add `--restart-devices` to automate this step.
 
+### `sessions`
+
+List and clean up ETW trace sessions created by `etwutils`. Useful after a run is killed before it can stop its session — orphaned `NefariusEtwCli-<pid>` sessions hold their provider enabled, and once the system or provider limit is reached every new run fails with an error.
+
+> [!IMPORTANT]  
+> **Admin required.** The `clean` action calls `ControlTrace(STOP)` and requires an elevated process.
+
+```text
+etwutils sessions <list|clean> [--all] [--prefix <name>] [--dry-run]
+```
+
+| Argument / Option | Description |
+|---|---|
+| `list` | Print all running ETW sessions; annotate sessions matching `--prefix` as `alive` or `dead` based on whether the owning process still exists |
+| `clean` | Stop sessions matching `--prefix` whose owning process is no longer running |
+| `--all` | For `clean`: also stop sessions whose process is still running. **Warning:** may interrupt another live `etwutils realtime` instance |
+| `--prefix <name>` | Session name prefix to target (default: `NefariusEtwCli-`) |
+| `--dry-run` | Print what would be stopped without stopping anything; exits 0 |
+
+#### Why sessions pile up
+
+`etwutils realtime` creates an ETW session named `NefariusEtwCli-<pid>`. When the process is killed (e.g. closing the terminal) the session is left behind because `ControlTrace(STOP)` never runs. Modern ETW providers can be enabled in up to 8 sessions simultaneously; legacy WPP/MOF providers allow only 1. Once the limit is reached, `EnableTraceEx2` returns `ERROR_NO_SYSTEM_RESOURCES` (0x5AA) and the next run fails immediately.
+
+#### Examples
+
+```text
+# List all running ETW sessions (annotates etwutils sessions as alive/dead)
+etwutils sessions list
+
+# Remove all dead NefariusEtwCli-<pid> sessions (safe for concurrent runs)
+etwutils sessions clean
+
+# Preview what would be removed without touching anything
+etwutils sessions clean --dry-run
+
+# Force-stop all NefariusEtwCli- sessions regardless of process state
+etwutils sessions clean --all
+
+# Target a custom session name prefix
+etwutils sessions list --prefix MyApp-
+etwutils sessions clean --prefix MyApp-
+```
+
 ### `inspect-pdb`
 
 Parse PDB files and report every embedded WPP provider GUID without starting an ETW session.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to list ETW sessions with alive/dead status and to clean orphaned sessions (options: --all, --prefix, --dry-run).
  * Library API to enumerate current ETW session names.

* **Bug Fixes / UX**
  * Improved error messaging when the provider reaches the maximum concurrent session limit, with actionable cleanup guidance.

* **Documentation**
  * README updated with sessions command usage and admin warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/Nefarius.Utilities.ETW/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->