### PR TITLE
Added more missing format specifiers

### DIFF
--- a/src/Deserializer/WPP/WppFormatter.cs
+++ b/src/Deserializer/WPP/WppFormatter.cs
@@ -17,7 +17,7 @@ internal static partial class WppFormatter
     [GeneratedRegex(@"(0[xX])?%(\d+)!([^!]*)!", RegexOptions.Compiled)]
     internal static partial Regex PlaceholderRegex();
 
-    [GeneratedRegex(@"^(?<pad>0)?(?<width>\d+)?(?<modifier>I\d+)?(?<specifier>[XxduU])$")]
+    [GeneratedRegex(@"^(?<pad>0)?(?<width>\d+)?(?<modifier>I\d+|ll|l|hh|h|I)?(?<specifier>[XxduUi])$")]
     internal static partial Regex NumericFormatTokenRegex();
 
     // Matches %!NAME! context markers (e.g. %!FUNC!, %!LEVEL!)
@@ -119,7 +119,8 @@ internal static partial class WppFormatter
                         // so map it to "D". All other specifiers (x/X → "X", d → "D") are safe
                         // to uppercase directly.
                         string rawSpecifier = numberMatch.Groups["specifier"].Value;
-                        string specifier = rawSpecifier is "u" or "U" ? "D" : rawSpecifier.ToUpperInvariant();
+                        // u/U = unsigned decimal; i = signed decimal (C alias of d); both map to .NET "D"
+                        string specifier = rawSpecifier is "u" or "U" or "i" ? "D" : rawSpecifier.ToUpperInvariant();
                         string suffix    = $"{pad}{width}";
 
                         string finalFormat = isHexPrefixed

--- a/tests/UnitTestWppFormatter.cs
+++ b/tests/UnitTestWppFormatter.cs
@@ -204,6 +204,91 @@ public class WppFormatterTests
     }
 
     // -----------------------------------------------------------------------
+    // Length-modifier specifiers (l, ll, h, hh — no-ops in .NET formatting)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void Substitute_FormatsLongDecimal_WithLModifier()
+    {
+        // %ld is the most common real-world case: long int printed as decimal
+        FunctionParameter param = MakeParam(ItemType.ItemLong, index: 1);
+        TraceMessageFormat format = MakeFormat("%1!ld!", param);
+
+        string result = WppFormatter.Substitute(format, Params((1, param, -12345)));
+
+        Assert.That(result, Is.EqualTo("-12345"));
+    }
+
+    [Test]
+    public void Substitute_FormatsUnsignedLong_WithLuModifier()
+    {
+        FunctionParameter param = MakeParam(ItemType.ItemLong, index: 1);
+        TraceMessageFormat format = MakeFormat("%1!lu!", param);
+
+        string result = WppFormatter.Substitute(format, Params((1, param, 4294967295U)));
+
+        Assert.That(result, Is.EqualTo("4294967295"));
+    }
+
+    [Test]
+    public void Substitute_FormatsHexLong_WithLxModifier()
+    {
+        FunctionParameter param = MakeParam(ItemType.ItemLong, index: 1);
+        TraceMessageFormat format = MakeFormat("%1!lx!", param);
+
+        // lowercase x maps to uppercase X in .NET; value should be rendered in hex
+        string result = WppFormatter.Substitute(format, Params((1, param, (int)0xABCD)));
+
+        Assert.That(result, Is.EqualTo("ABCD"));
+    }
+
+    [Test]
+    public void Substitute_FormatsHexLong_WithLXModifier()
+    {
+        FunctionParameter param = MakeParam(ItemType.ItemLong, index: 1);
+        TraceMessageFormat format = MakeFormat("0x%1!lX!", param);
+
+        string result = WppFormatter.Substitute(format, Params((1, param, (int)0xBEEF)));
+
+        Assert.That(result, Is.EqualTo("0xBEEF"));
+    }
+
+    [Test]
+    public void Substitute_FormatsShortDecimal_WithHModifier()
+    {
+        FunctionParameter param = MakeParam(ItemType.ItemShort, index: 1);
+        TraceMessageFormat format = MakeFormat("%1!hd!", param);
+
+        string result = WppFormatter.Substitute(format, Params((1, param, (short)42)));
+
+        Assert.That(result, Is.EqualTo("42"));
+    }
+
+    [Test]
+    public void Substitute_FormatsUnsignedLong_ZeroPadded_WithLuModifier()
+    {
+        // Confirms pad/width still works when a length modifier is present
+        FunctionParameter param = MakeParam(ItemType.ItemLong, index: 1);
+        TraceMessageFormat format = MakeFormat("%1!08lu!", param);
+
+        string result = WppFormatter.Substitute(format, Params((1, param, 42U)));
+
+        Assert.That(result, Is.EqualTo("00000042"));
+    }
+
+    [Test]
+    public void Substitute_FormatsDecimalInteger_WithISpecifier()
+    {
+        // %i is a C alias for %d (signed decimal)
+        FunctionParameter param = MakeParam(ItemType.ItemLong, index: 1);
+        TraceMessageFormat format = MakeFormat("val=%1!i!", param);
+
+        string result = WppFormatter.Substitute(format, Params((1, param, -99)));
+
+        Assert.That(result, Is.EqualTo("val=-99"));
+    }
+
+    // -----------------------------------------------------------------------
     // Format-error fallback
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended numeric placeholder parsing to recognize additional WPP format modifier combinations and specifier options. Updated .NET formatting mapping to support a broader range of decimal and integer numeric format specifications.

* **Tests**
  * Added comprehensive unit test coverage with seven new tests validating numeric formatting scenarios including length modifiers, signed/unsigned decimals, hexadecimal formats with optional padding, and various integer specifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->